### PR TITLE
Fix to filter specific type of record

### DIFF
--- a/ansible_collections/infoblox/b1ddi_modules/plugins/modules/b1_a_record_gather.py
+++ b/ansible_collections/infoblox/b1ddi_modules/plugins/modules/b1_a_record_gather.py
@@ -122,7 +122,7 @@ def main():
         host=dict(required=True, type='str'),
         comment=dict(type='str'),
         fields=dict(type='list'),
-        filters=dict(type='dict', default={}),
+        filters=dict(type='dict', default={"type": "A"}),
         tags=dict(type='list', elements='dict', default=[{}]),
         state=dict(type='str', default='present', choices=['present','absent','gather'])
     )

--- a/ansible_collections/infoblox/b1ddi_modules/plugins/modules/b1_cname_record_gather.py
+++ b/ansible_collections/infoblox/b1ddi_modules/plugins/modules/b1_cname_record_gather.py
@@ -122,7 +122,7 @@ def main():
         host=dict(required=True, type='str'),
         comment=dict(type='str'),
         fields=dict(type='list'),
-        filters=dict(type='dict', default={}),
+        filters=dict(type='dict', default={"type": "CNAME"}),
         tags=dict(type='list', elements='dict', default=[{}]),
         state=dict(type='str', default='present', choices=['present','absent','gather'])
     )

--- a/ansible_collections/infoblox/b1ddi_modules/plugins/modules/b1_ns_record_gather.py
+++ b/ansible_collections/infoblox/b1ddi_modules/plugins/modules/b1_ns_record_gather.py
@@ -122,7 +122,7 @@ def main():
         host=dict(required=True, type='str'),
         comment=dict(type='str'),
         fields=dict(type='list'),
-        filters=dict(type='dict', default={}),
+        filters=dict(type='dict', default={"type": "NS"}),
         tags=dict(type='list', elements='dict', default=[{}]),
         state=dict(type='str', default='present', choices=['present','absent','gather'])
     )

--- a/ansible_collections/infoblox/b1ddi_modules/plugins/modules/b1_ptr_record_gather.py
+++ b/ansible_collections/infoblox/b1ddi_modules/plugins/modules/b1_ptr_record_gather.py
@@ -122,7 +122,7 @@ def main():
         host=dict(required=True, type='str'),
         comment=dict(type='str'),
         fields=dict(type='list'),
-        filters=dict(type='dict', default={}),
+        filters=dict(type='dict', default={"type": "PTR"}),
         tags=dict(type='list', elements='dict', default=[{}]),
         state=dict(type='str', default='present', choices=['present','absent','gather'])
     )


### PR DESCRIPTION
### Issue/Feature description

* Unable to filter a specific type of record using DNS gather modules.

### How it was fixed/implemented

* Added type of record as a default filter option in `argument_spec`

### Tests

No tests

### Reviewers

@amishra2-infoblox 