### PR TITLE
Added alias fields for 'dns_rdata' and 'dns_name_in_zone' filter fields

### DIFF
--- a/ansible_collections/infoblox/b1ddi_modules/plugins/modules/b1_a_record_gather.py
+++ b/ansible_collections/infoblox/b1ddi_modules/plugins/modules/b1_a_record_gather.py
@@ -77,6 +77,10 @@ def get_a_record_gather(data):
     flag=0
     fields=data['fields']
     filters=data['filters']
+    if 'name' in filters:
+        filters['dns_name_in_zone'] = filters.pop('name')
+    if 'address' in filters:
+        filters['dns_rdata'] = filters.pop('address')
     if fields!=None and isinstance(fields, list):
         temp_fields = ",".join(fields)
         endpoint = endpoint+"?_fields="+temp_fields

--- a/ansible_collections/infoblox/b1ddi_modules/plugins/modules/b1_cname_record_gather.py
+++ b/ansible_collections/infoblox/b1ddi_modules/plugins/modules/b1_cname_record_gather.py
@@ -77,6 +77,10 @@ def get_cname_record_gather(data):
     flag=0
     fields=data['fields']
     filters=data['filters']
+    if 'name' in filters:
+        filters['dns_name_in_zone'] = filters.pop('name')
+    if 'canonical' in filters:
+        filters['dns_rdata'] = filters.pop('canonical')
     if fields!=None and isinstance(fields, list):
         temp_fields = ",".join(fields)
         endpoint = endpoint+"?_fields="+temp_fields

--- a/ansible_collections/infoblox/b1ddi_modules/plugins/modules/b1_cname_record_gather.py
+++ b/ansible_collections/infoblox/b1ddi_modules/plugins/modules/b1_cname_record_gather.py
@@ -79,8 +79,8 @@ def get_cname_record_gather(data):
     filters=data['filters']
     if 'name' in filters:
         filters['dns_name_in_zone'] = filters.pop('name')
-    if 'canonical' in filters:
-        filters['dns_rdata'] = filters.pop('canonical')
+    if 'cname' in filters:
+        filters['dns_rdata'] = filters.pop('cname')
     if fields!=None and isinstance(fields, list):
         temp_fields = ",".join(fields)
         endpoint = endpoint+"?_fields="+temp_fields

--- a/ansible_collections/infoblox/b1ddi_modules/plugins/modules/b1_ns_record_gather.py
+++ b/ansible_collections/infoblox/b1ddi_modules/plugins/modules/b1_ns_record_gather.py
@@ -77,6 +77,10 @@ def get_ns_record_gather(data):
     flag=0
     fields=data['fields']
     filters=data['filters']
+    if 'name' in filters:
+        filters['dns_name_in_zone'] = filters.pop('name')
+    if 'nameserver' in filters:
+        filters['dns_rdata'] = filters.pop('nameserver')
     if fields!=None and isinstance(fields, list):
         temp_fields = ",".join(fields)
         endpoint = endpoint+"?_fields="+temp_fields

--- a/ansible_collections/infoblox/b1ddi_modules/plugins/modules/b1_ns_record_gather.py
+++ b/ansible_collections/infoblox/b1ddi_modules/plugins/modules/b1_ns_record_gather.py
@@ -79,8 +79,8 @@ def get_ns_record_gather(data):
     filters=data['filters']
     if 'name' in filters:
         filters['dns_name_in_zone'] = filters.pop('name')
-    if 'nameserver' in filters:
-        filters['dns_rdata'] = filters.pop('nameserver')
+    if 'dname' in filters:
+        filters['dns_rdata'] = filters.pop('dname')
     if fields!=None and isinstance(fields, list):
         temp_fields = ",".join(fields)
         endpoint = endpoint+"?_fields="+temp_fields


### PR DESCRIPTION
### Issue/Feature description

* Unable to gather DNS records using "Name" and "Address" under filters field.
* Modules affected:
     * b1_a_record_gather
     * b1_cname_records_gather
     * b1_ns_record_gather

### How it was fixed/implemented

* Added alias fields for the `dns_rdata` and `dns_name_in_zone` filter fields.
* For A Record, the alias for `dns_name_in_zone` is `name` and for `dns_rdata` is `address`.
* For CNAME Record, the alias for `dns_name_in_zone` is `name` and for `dns_rdata` is `cname`.
* For NS Record, the alias for `dns_name_in_zone` is `name` and for `dns_rdata` is `dname`.

### Tests

No tests

### Reviewers

@amishra2-infoblox 