### PR TITLE
Added alias fields for 'dns_rdata' and 'dns_name_in_zone' filter fields for PTR record and documentation changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ Requirements
  
 - Ansible 2.10 and above
 - Python 3.9
-- JsonPath ( pip install Jsonpath )
 
 Collection Overview
 ===================
@@ -27,7 +26,7 @@ DNS
 - `b1_a_record`: Module to create and delete A record.
 - `b1_a_record_gather`: Module to gather information about existing A records.
 - `b1_cname_record`: Module to create and delete CNAME record
-- `b1_cname_records_gather`: Module to gather information about existing CNAME records.
+- `b1_cname_record_gather`: Module to gather information about existing CNAME records.
 - `b1_ptr_record`: Module to create and delete PTR record
 - `b1_ptr_record_gather`: Module to gather information about existing PTR records.
 - `b1_ns_record`: Module to create and delete NS record
@@ -58,7 +57,7 @@ The `b1ddi_modules` collection can be installed from git repository through eith
 
 - Install the collection directly from the [GitHub](https://github.com/infobloxopen/bloxone-ansible/tree/main/ansible_collections/infoblox/b1ddi_modules) repository using the latest commit on the master branch:
 ```shell
-$ ansible-galaxy collection install git+https://github.com/infobloxopen/bloxone-ansible#ansible_collections/infoblox/b1ddi_modules
+ansible-galaxy collection install git+https://github.com/infobloxopen/bloxone-ansible#ansible_collections/infoblox/b1ddi_modules
 ```
 
 - Install the collection by defining in requirements.yaml 

--- a/ansible_collections/infoblox/b1ddi_modules/plugins/modules/b1_a_record.py
+++ b/ansible_collections/infoblox/b1ddi_modules/plugins/modules/b1_a_record.py
@@ -78,45 +78,55 @@ options:
 
   
 EXAMPLES = '''
-    - name: GET all DNS VIEW
+    - name: GET all A Records
       b1_a_record:
         api_key: "{{ api_key }}"
         host: "{{ host }}"
         state: get
 
-    - name: GET DNS VIEW of speceific Zone
+    - name: GET A Records of a zone
       b1_a_record:
         api_key: "{{ api_key }}"
         host: "{{ host }}"
         zone: "{{ Zone_name }}"
         state: get
 
-    - name: GET Specific View
+    - name: GET Specific A Record
       b1_a_record:
         api_key: "{{ api_key }}"
         host: "{{ host }}"
         zone: "{{ Zone_name }}"
-        name: "{{ name of the view }}"
+        name: "{{ domain name of A Record }}"
         state: get
 
-    - name: CREATE DNS View 
+    - name: CREATE A Record
       b1_a_record:
         api_key: "{{ api_key }}"
         host: "{{ host }}"
         zone: "{{ Zone_name }}"
-        address: "{{ ip address of the zone }}"
-        name: "{{ name of the view }}"
+        address: "{{ ip address of A Record }}"
+        name: "{{ domain name of A Record }}"
         state: present
 
 
-    - name: UPADAT DNS view # Only update of Name is supported in this release
+    - name: UPADATE A Record # Only update of Name is supported in this release
       b1_a_record:
         api_key: "{{ api_key }}"
         host: "{{ host }}"
         zone: "{{ Zone_name }}"
-        address: "{{ ip address of the zone }}"
-        name: '{"new_name": "New Name of the View", "old_name": "Old name of the view"}'
+        address: "{{ ip address of the record }}"
+        name: '{"new_name": "New domain name of the record", "old_name": "Old domain name of the record"}'
         state: present
+
+
+    - name: Delete A record
+      b1_ptr_record:
+        api_key: "{{ api_key }}"
+        host: "{{ host }}"
+        zone: "{{ Zone_name }}"
+        name: "{{ domain name of A record }"
+        address:  "{{ address of A record }}"
+        state: absent
 '''
 
 RETURN = ''' # '''

--- a/ansible_collections/infoblox/b1ddi_modules/plugins/modules/b1_cname_record.py
+++ b/ansible_collections/infoblox/b1ddi_modules/plugins/modules/b1_cname_record.py
@@ -96,7 +96,7 @@ EXAMPLES = '''
         api_key: "{{ api_key }}"
         host: "{{ host }}"
         zone: "{{ Zone_name }}"
-        name: "{{ name of the view }}"
+        name: "{{ Alias of Cname }}"
         state: get
 
     - name: CREATE CNAME Record

--- a/ansible_collections/infoblox/b1ddi_modules/plugins/modules/b1_ptr_record.py
+++ b/ansible_collections/infoblox/b1ddi_modules/plugins/modules/b1_ptr_record.py
@@ -97,7 +97,7 @@ EXAMPLES = '''
         api_key: "{{ api_key }}"
         host: "{{ host }}"
         zone: "{{ Zone_name }}"
-        name: "
+        name: "{{ domain name of PTR record }"
         state: get
 
     - name: Create PTR record

--- a/ansible_collections/infoblox/b1ddi_modules/plugins/modules/b1_ptr_record_gather.py
+++ b/ansible_collections/infoblox/b1ddi_modules/plugins/modules/b1_ptr_record_gather.py
@@ -77,6 +77,10 @@ def get_ptr_record_gather(data):
     flag=0
     fields=data['fields']
     filters=data['filters']
+    if 'address' in filters:
+        filters['dns_name_in_zone'] = filters.pop('address')
+    if 'dname' in filters:
+        filters['dns_rdata'] = filters.pop('dname')
     if fields!=None and isinstance(fields, list):
         temp_fields = ",".join(fields)
         endpoint = endpoint+"?_fields="+temp_fields

--- a/sample_playbook/cud_dns_view.yaml
+++ b/sample_playbook/cud_dns_view.yaml
@@ -41,9 +41,9 @@
          host: "{{ host }}"
          state: present
 
-#    - name: Delete DNS View
-#      b1_dns_view:
-#         name: "Test-View2"
-#         api_key: "{{ api }}"
-#         host: "{{ host }}"
-#         state: absent
+    - name: Delete DNS View
+      b1_dns_view:
+         name: "Test-View2"
+         api_key: "{{ api }}"
+         host: "{{ host }}"
+         state: absent

--- a/sample_playbook/cud_ipam_addressblock.yaml
+++ b/sample_playbook/cud_ipam_addressblock.yaml
@@ -45,12 +45,11 @@
         host: "{{ host }}"
         state: present
 
-#    #  Delete an Address Block in a given IP space
-#    - name: Delete Address Block
-#      b1_ipam_address_block:
-#        address: "172.16.0.16/28"
-#        space: "Test-Ansible-Space"
-#        api_key: "{{ api }}"
-#        host: "{{ host }}"
-#        state: absent
-
+    #  Delete an Address Block in a given IP space
+    - name: Delete Address Block
+      b1_ipam_address_block:
+        address: "172.16.0.16/28"
+        space: "Test-Ansible-Space"
+        api_key: "{{ api }}"
+        host: "{{ host }}"
+        state: absent

--- a/sample_playbook/cud_ipam_ipspace.yaml
+++ b/sample_playbook/cud_ipam_ipspace.yaml
@@ -32,10 +32,10 @@
         api_key: "{{ api }}"
         state: present
 
-#    # Delete the IP space
-#    - name: Delete IP space
-#      b1_ipam_ip_space:
-#        name: "Test-Ansible-Space"
-#        host: "{{ host }}"
-#        api_key: "{{ api }}"
-#        state: absent
+    # Delete the IP space
+    - name: Delete IP space
+      b1_ipam_ip_space:
+        name: "Test-Ansible-Space"
+        host: "{{ host }}"
+        api_key: "{{ api }}"
+        state: absent

--- a/sample_playbook/cud_ipam_range.yaml
+++ b/sample_playbook/cud_ipam_range.yaml
@@ -39,7 +39,7 @@
         state: present
 
     #  Delete the Range in a given IP space
-    - name: Delete an existing Subnet.
+    - name: Delete an existing Range.
       b1_ipam_range:
         space: "Test-Ansible-Space"
         start: "172.16.0.50"

--- a/sample_playbook/cud_ipam_reserved_address.yaml
+++ b/sample_playbook/cud_ipam_reserved_address.yaml
@@ -10,41 +10,41 @@
 
   tasks:
     #  Create a ipv4 reserved address in a given IP space
-#    - name: Create ipv4 reserved address in a given IP Space
-#      b1_ipam_ipv4_reservation:
-#        space: "Test-Ansible-Space"
-#        address: '172.16.0.18'
-#        name: "Test-Address-18"
-#        comment: "This is the test address "
-#        tags:
-#          - "Org": "Infoblox"
-#        api_key: "{{ api }}"
-#        host: "{{ host }}"
-#        state: present
-#
-#    #  Update the ipv4 reserved address in a given IP space
-#    - name: Update ipv4 reserved address in a given IP Space
-#      b1_ipam_ipv4_reservation:
-#        space: "Test-Ansible-Space"
-#        address: '{"new_address": "172.16.0.15", "old_address": "172.16.0.18"}'
-#        name: "Test-Ansible-address_15"
-#        comment: "This is the test address-mod"
-#        api_key: "{{ api }}"
-#        host: "{{ host }}"
-#        state: present
-#
-#    #  Create a ipv4 reservation in a given IP space using next_available_address_block
-#    - name: Create reserved address using next-available subnet
-#      b1_ipam_ipv4_reservation:
-#        space: "Test-Ansible-Space"
-#        address: '{"next_available_ip": {"subnet": "172.16.0.0/24"}}'
-#        name: "Test-Ansible-AB_nextAvailable-reservedIP"
-#        comment: "This is the test reserved ip using nextavailable"
-#        api_key: "{{ api }}"
-#        host: "{{ host }}"
-#        state: present
+    - name: Create ipv4 reserved address in a given IP Space
+      b1_ipam_ipv4_reservation:
+        space: "Test-Ansible-Space"
+        address: '172.16.0.18'
+        name: "Test-Address-18"
+        comment: "This is the test address "
+        tags:
+          - "Org": "Infoblox"
+        api_key: "{{ api }}"
+        host: "{{ host }}"
+        state: present
 
-    #  Delete an Address Block in a given IP space
+    #  Update the ipv4 reserved address in a given IP space
+    - name: Update ipv4 reserved address in a given IP Space
+      b1_ipam_ipv4_reservation:
+        space: "Test-Ansible-Space"
+        address: '{"new_address": "172.16.0.15", "old_address": "172.16.0.18"}'
+        name: "Test-Ansible-address_15"
+        comment: "This is the test address-mod"
+        api_key: "{{ api }}"
+        host: "{{ host }}"
+        state: present
+
+    #  Create a ipv4 reservation in a given IP space using next_available_address_block
+    - name: Create reserved address using next-available subnet
+      b1_ipam_ipv4_reservation:
+        space: "Test-Ansible-Space"
+        address: '{"next_available_ip": {"subnet": "172.16.0.0/24"}}'
+        name: "Test-Ansible-AB_nextAvailable-reservedIP"
+        comment: "This is the test reserved ip using nextavailable"
+        api_key: "{{ api }}"
+        host: "{{ host }}"
+        state: present
+
+    #  Delete an existing Reservation
     - name: Delete ipv4 reservation address.
       b1_ipam_ipv4_reservation:
         address: "172.16.0.4"

--- a/sample_playbook/cud_ipam_subnet.yaml
+++ b/sample_playbook/cud_ipam_subnet.yaml
@@ -35,13 +35,13 @@
         host: "{{ host }}"
         state: present
 
-    #  Create a subnet in a given IP space using next_available_address_block
-    - name: Create Address Block using next-available subnet
-      b1_ipam_address_block:
-        space: "Test-Ansible-Space"
-        address: '{"next_available_address_block": {"cidr": "28", "count": "2", "parent_block": "172.16.0.0/24"}}'
-        name: "Test-Ansible-AB_nextAvailable"
-        comment: "This is the test subnet creation using nextavailable"
+    #  Create a subnet in a given IP space using next_available_subnet
+    - name: Create Subnet using next available function
+      b1_ipam_subnet:
+        address: '{"next_available_subnet": {"parent_block": "10.0.0.0/16", "cidr": "24", "count": "1"}}'
+        space: Test-Ansible-Space
+        name: "Test-Ansible-Subnet"
+        comment: "This is the test AB creation"
         api_key: "{{ api }}"
         host: "{{ host }}"
         state: present


### PR DESCRIPTION
### Issue/Feature description

* Unable to gather PTR records using "Name" and "Address" under filters field
* Modules affected:
     * b1_ptr_record_gather
     
* Infoblox BloxOne Collection for Ansible Document needs to be updated

### How it was fixed/implemented

* Added alias fields for the `dns_rdata` and `dns_name_in_zone` filter fields.
* For PTR Record, the alias for `dns_name_in_zone` is `address` and for `dns_rdata` is `dname`.
* Made the required documentation changes in README and updated the sample playbooks.

### Tests

No tests

### Reviewers

@sriram-kannan-infoblox, @ranjishmp 