### PR TITLE
Added the dhcp_options feature in the b1_ipam_subnet module

### DIFF
--- a/ansible_collections/infoblox/b1ddi_modules/plugins/module_utils/b1ddi.py
+++ b/ansible_collections/infoblox/b1ddi_modules/plugins/module_utils/b1ddi.py
@@ -150,3 +150,21 @@ class Utilities(object):
             for k,v in i.items():
                 payload[k]=v
         return payload
+    
+    def dhcp_options(self, key, data, dhcp_option_codes):
+        """Create a list of DHCP option dicts"""
+        payload = []
+        for i in data[key]:
+            for k, v in i.items():
+                dhcp_option = {}
+                for item in dhcp_option_codes:
+                    if item["name"] == k:
+                        dhcp_option_code = item["id"]
+                        break
+                if dhcp_option_code:
+                    dhcp_option["option_code"] = dhcp_option_code
+                    dhcp_option["option_value"] = v
+                    dhcp_option["type"] = "option"
+                    payload.append(dhcp_option)
+        return payload
+

--- a/ansible_collections/infoblox/b1ddi_modules/plugins/modules/b1_ipam_subnet.py
+++ b/ansible_collections/infoblox/b1ddi_modules/plugins/modules/b1_ipam_subnet.py
@@ -334,6 +334,7 @@ def main():
         space=dict(type='str'),
         dhcp_host=dict(type='str'),
         comment=dict(type='str'),
+	dhcp_options=dict(type="list", elements="dict", default=[{}])
         tags=dict(type='list', elements='dict', default=[{}]),
         state=dict(type='str', default='present', choices=['present','absent','get'])
     )

--- a/ansible_collections/infoblox/b1ddi_modules/plugins/modules/b1_ipam_subnet.py
+++ b/ansible_collections/infoblox/b1ddi_modules/plugins/modules/b1_ipam_subnet.py
@@ -237,6 +237,25 @@ def create_subnet(data):
                 payload['comment'] = data['comment'] if 'comment' in data.keys() else ''
                 if 'tags' in data.keys() and data['tags']!=None:
                     payload['tags']=helper.flatten_dict_object('tags',data)                
+		if "dhcp_options" in data.keys() and data["dhcp_options"] != None:
+                    dhcp_option_codes = connector.get("/api/ddi/v1/dhcp/option_code")
+                    if (
+                        "results" in dhcp_option_codes[2].keys()
+                        and len(dhcp_option_codes[2]["results"]) > 0
+                    ):
+                        payload["dhcp_options"] = helper.dhcp_options(
+                            "dhcp_options", data, dhcp_option_codes[2]["results"]
+                        )
+                    else:
+                        return (
+                            True,
+                            False,
+                            {
+                                "status": "400",
+                                "response": "Error in fetching DHCP option codes",
+                                "data": data,
+                            },
+                        )
                 return connector.create('/api/ddi/v1/ipam/subnet', payload)
     else:
         return(True, False, {'status': '400', 'response': 'Address or IP Space not defined','data':data})                


### PR DESCRIPTION
- Added the option to mark DHCP scope options during subnet creation in the b1_ipam_subnet module.
-  Multiple DHCP options can be added by passing them in a list.

  ```
tasks:
    - name: Create Site Subnets in BloxOne
      b1_ipam_subnet:
        space: "Test_Space"
        address: "{{ item['value']['subnet'] }}/{{ item['value']['cidr'] }}"
        name: "{{ item['value']['description'] }}"
        api_key: "{{ api }}"
        host: "{{ host }}"
        state: present
        dhcp_options:
          - routers: '10.98.36.1'
          - log-servers: '10.98.36.2'
```