### PR TITLE
BloxoneAnsibleModule util and IP space module

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,30 @@
+name: integration
+
+on:
+  push:
+    branches:
+      - v2
+  schedule:
+    # every day at 02:00 UTC
+    - cron: '0 2 * * *'
+
+jobs:
+  integration:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v4
+        with:
+          path: infoblox.bloxone
+
+      - name: Set up integration_config.yml
+        run: |
+          echo "api_key: ${{ secrets.BLOXONE_API_KEY }}" > infoblox.bloxone/tests/integration/integration_config.yml
+          echo "csp_url: ${{ secrets.BLOXONE_CSP_URL }}" >> infoblox.bloxone/tests/integration/integration_config.yml
+
+      - uses: ansible-community/ansible-test-gh-action@v1.15.0
+        with:
+          collection-src-directory: infoblox.bloxone
+          ansible-core-version: 'stable-2.15'
+          target-python-version: '3.11'
+          testing-type: integration

--- a/changelogs/fragments/32-ip-space.yml
+++ b/changelogs/fragments/32-ip-space.yml
@@ -1,0 +1,3 @@
+deprecated_features:
+  - b1_ipam_ip_space - is deprecated in favor of `ipam_ip_space`.
+  - b1_ipam_ip_space_gather - is deprecated in favor of `ipam_ip_space_info`.

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,0 +1,8 @@
+action_groups:
+  all:
+    - metadata:
+        extend_group:
+          - ipam
+  ipam:
+    - ipam_ip_space
+    - ipam_ip_space_info

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -6,3 +6,14 @@ action_groups:
   ipam:
     - ipam_ip_space
     - ipam_ip_space_info
+
+plugin_routing:
+    modules:
+        b1_ipam_ip_space:
+            deprecation:
+                removal_version: 3.0.0
+                warning_text: Use infoblox.bloxone.ipam_ip_space instead.
+        b1_ipam_ip_space_gather:
+            deprecation:
+                removal_version: 3.0.0
+                warning_text: Use infoblox.bloxone.ipam_ip_space_info instead.

--- a/plugins/doc_fragments/common.py
+++ b/plugins/doc_fragments/common.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: Infoblox
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+
+class ModuleDocFragment:
+    DOCUMENTATION = r"""
+options:
+    api_key:
+        description:
+          - The API token for authentication against Infoblox BloxOne API. If not set, the environment variable E(BLOXONE_API_KEY) will be used.
+        type: str
+        aliases: [ bloxone_api_key ]
+
+    csp_url:
+        description:
+          - The Infoblox Cloud Services Portal (CSP) URL. If not set, the environment variable E(BLOXONE_CSP_URL) will be used.
+        type: str
+        aliases: [ bloxone_csp_url ]
+        default: 'https://csp.infoblox.com'
+"""

--- a/plugins/module_utils/modules.py
+++ b/plugins/module_utils/modules.py
@@ -1,0 +1,115 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2024 Infoblox
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import traceback
+
+from ansible.module_utils.basic import AnsibleModule, env_fallback, missing_required_lib
+
+try:
+    import bloxone_client
+
+    HAS_BLOXONE_CLIENT = True
+    BLOXONE_CLIENT_IMP_ERR = None
+except ImportError:
+    HAS_BLOXONE_CLIENT = False
+    BLOXONE_CLIENT_IMP_ERR = traceback.format_exc()
+
+
+class BloxoneAnsibleModule(AnsibleModule):
+    def __init__(self, *args, **kwargs):
+        # Add common arguments to the module argument_spec
+        args_full = bloxone_client_common_argument_spec()
+        try:
+            args_full.update(kwargs["argument_spec"])
+        except (TypeError, NameError):
+            pass
+        kwargs["argument_spec"] = args_full
+
+        super(BloxoneAnsibleModule, self).__init__(*args, **kwargs)
+        self._client = None
+
+        if not HAS_BLOXONE_CLIENT:
+            self.fail_json(
+                msg=missing_required_lib(
+                    "bloxone_client",
+                    url="https://github.com/infobloxopen/bloxone-python-client",
+                ),
+                exception=BLOXONE_CLIENT_IMP_ERR,
+            )
+
+    @property
+    def client(self):
+        if not self._client:
+            self._client = _get_client(self)
+
+        return self._client
+
+    def is_changed(self, existing, payload):
+        return _is_changed(existing, payload)
+
+
+def bloxone_client_common_argument_spec():
+    return dict(
+        api_key=dict(
+            type="str", aliases=["bloxone_api_key"], fallback=(env_fallback, ["BLOXONE_API_KEY"]), no_log=True
+        ),
+        csp_url=dict(
+            type="str",
+            aliases=["bloxone_csp_url"],
+            fallback=(env_fallback, ["BLOXONE_CSP_URL"]),
+            default="https://csp.infoblox.com",
+        ),
+    )
+
+
+def _get_client(module):
+    config = _get_client_config(module)
+    client = bloxone_client.ApiClient(config)
+    return client
+
+
+def _get_client_config(module):
+    csp_url = module.params.get("csp_url")
+    api_key = module.params.get("api_key")
+
+    # Use None for empty values, so that the client can handle it
+    if not csp_url:
+        csp_url = None
+    if not api_key:
+        api_key = None
+
+    config = bloxone_client.Configuration(
+        csp_url=csp_url,
+        api_key=api_key,
+        client_name="ansible",
+    )
+    config.debug = True
+    return config
+
+
+def _is_changed(existing, payload):
+    """
+    Check if the existing object is different from the payload.
+    The payload keys that are not none are considered for comparison, others are ignored.
+    If the value is a complex object, the comparison is done recursively.
+
+    :param existing:
+    :param payload:
+    :return:
+    """
+    changed = False
+    for k, v in payload.items():
+        if v is not None:
+            if isinstance(v, dict):
+                changed = _is_changed(existing[k], v)
+            elif existing[k] != v:
+                changed = True
+        if changed:
+            break
+
+    return changed

--- a/plugins/modules/b1_ipam_ip_space.py
+++ b/plugins/modules/b1_ipam_ip_space.py
@@ -13,6 +13,9 @@ module: b1_ipam_ip_space
 author: "Amit Mishra (@amishra), Sriram Kannan(@kannans)"
 short_description: Configure IP space on Infoblox BloxOne DDI
 version_added: "1.0.1"
+deprecated:
+  removed_in: 3.0.0
+  alternative: Use M(ipam_ip_space) instead.
 description:
   -  Create, Update and Delete IP spaces on Infoblox BloxOne DDI. This module manages the IPAM IP space object using BloxOne REST APIs.
 requirements:

--- a/plugins/modules/b1_ipam_ip_space.py
+++ b/plugins/modules/b1_ipam_ip_space.py
@@ -15,7 +15,8 @@ short_description: Configure IP space on Infoblox BloxOne DDI
 version_added: "1.0.1"
 deprecated:
   removed_in: 3.0.0
-  alternative: Use M(ipam_ip_space) instead.
+  why: This module is deprecated and will be removed in version 3.0.0. Use M(infoblox.bloxone.ipam_ip_space) instead.
+  alternative: Use M(infoblox.bloxone.ipam_ip_space) instead.
 description:
   -  Create, Update and Delete IP spaces on Infoblox BloxOne DDI. This module manages the IPAM IP space object using BloxOne REST APIs.
 requirements:

--- a/plugins/modules/b1_ipam_ip_space_gather.py
+++ b/plugins/modules/b1_ipam_ip_space_gather.py
@@ -14,6 +14,9 @@ author: "Amit Mishra (@amishra), Sriram Kannan(@kannans)"
 contributor: "Chris Marrison (@ccmarris)"
 short_description: Configure IP space on Infoblox BloxOne DDI
 version_added: "1.1.0"
+deprecated:
+  removed_in: 3.0.0
+  alternative: Use M(ipam_ip_space) instead.
 description:
   - Gather facts about IP spaces in Infoblox BloxOne DDI. This module manages the gather fact of IPAM IP space object using BloxOne REST APIs.
 requirements:

--- a/plugins/modules/b1_ipam_ip_space_gather.py
+++ b/plugins/modules/b1_ipam_ip_space_gather.py
@@ -16,7 +16,8 @@ short_description: Configure IP space on Infoblox BloxOne DDI
 version_added: "1.1.0"
 deprecated:
   removed_in: 3.0.0
-  alternative: Use M(ipam_ip_space) instead.
+  why: This module is deprecated and will be removed in version 3.0.0. Use M(infoblox.bloxone.ipam_ip_space) instead.
+  alternative: Use M(infoblox.bloxone.ipam_ip_space) instead.
 description:
   - Gather facts about IP spaces in Infoblox BloxOne DDI. This module manages the gather fact of IPAM IP space object using BloxOne REST APIs.
 requirements:

--- a/plugins/modules/ipam_ip_space.py
+++ b/plugins/modules/ipam_ip_space.py
@@ -31,842 +31,749 @@ options:
             - absent
         default: present
     asm_config:
-        description: >
-            The Automated Scope Management configuration for the IP space.
+        description:
+            - "The Automated Scope Management configuration for the IP space."
         type: dict
         suboptions:
             asm_threshold:
-                description: >
-                    ASM shows the number of addresses forecast to be used I(forecast)periodI( days in the future, if it is greater than )asmI(threshold) percent * I(dhcp)totalI( (see )dhcpI(utilization)) then the subnet is flagged.
+                description:
+                    - "ASM shows the number of addresses forecast to be used I(forecast_period) days in the future, if it is greater than I(asm_threshold) percent * I(dhcp_total) (see I(dhcp_utilization)) then the subnet is flagged."
                 type: int
             enable:
-                description: >
-                    Indicates if Automated Scope Management is enabled.
+                description:
+                    - "Indicates if Automated Scope Management is enabled."
                 type: bool
             enable_notification:
-                description: >
-                    Indicates if ASM should send notifications to the user.
+                description:
+                    - "Indicates if ASM should send notifications to the user."
                 type: bool
             forecast_period:
-                description: >
-                    The forecast period in days.
+                description:
+                    - "The forecast period in days."
                 type: int
             growth_factor:
-                description: >
-                    Indicates the growth in the number or percentage of IP addresses.
+                description:
+                    - "Indicates the growth in the number or percentage of IP addresses."
                 type: int
             growth_type:
-                description: >
-                    The type of factor to use: I(percent) or I(count).
+                description:
+                    - "The type of factor to use: I(percent) or I(count)."
                 type: str
             history:
-                description: >
-                    The minimum amount of history needed before ASM can run on this subnet.
+                description:
+                    - "The minimum amount of history needed before ASM can run on this subnet."
                 type: int
             min_total:
-                description: >
-                    The minimum size of range needed for ASM to run on this subnet.
+                description:
+                    - "The minimum size of range needed for ASM to run on this subnet."
                 type: int
             min_unused:
-                description: >
-                    The minimum percentage of addresses that must be available outside of the DHCP ranges and fixed addresses
-                    when making a suggested change..
+                description:
+                    - "The minimum percentage of addresses that must be available outside of the DHCP ranges and fixed addresses when making a suggested change.."
                 type: int
             reenable_date:
                 description: ""
                 type: str
     comment:
-        description: >
-            The description for the IP space. May contain 0 to 1024 characters. Can include UTF-8.
+        description:
+            - "The description for the IP space. May contain 0 to 1024 characters. Can include UTF-8."
         type: str
     ddns_client_update:
-        description: >
-            Controls who does the DDNS updates.
-            
-            Valid values are:
-            * I(client): DHCP server updates DNS if requested by client.
-            * I(server): DHCP server always updates DNS, overriding an update request from the client, unless the client requests no updates.
-            * I(ignore): DHCP server always updates DNS, even if the client says not to.
-            * I(over)clientI(update): Same as I(server). DHCP server always updates DNS, overriding an update request from the client, unless the client requests no updates.
-            * I(over)noI(update): DHCP server updates DNS even if the client requests that no updates be done. If the client requests to do the update, DHCP server allows it.
-            
-            Defaults to I(client).
+        description:
+            - "Controls who does the DDNS updates."
+            - "Valid values are:"
+            - "* I(client): DHCP server updates DNS if requested by client."
+            - "* I(server): DHCP server always updates DNS, overriding an update request from the client, unless the client requests no updates."
+            - "* I(ignore): DHCP server always updates DNS, even if the client says not to."
+            - "* I(over_client_update): Same as I(server). DHCP server always updates DNS, overriding an update request from the client, unless the client requests no updates."
+            - "* I(over_no_update): DHCP server updates DNS even if the client requests that no updates be done. If the client requests to do the update, DHCP server allows it."
+            - "Defaults to I(client)."
         type: str
     ddns_conflict_resolution_mode:
-        description: >
-            The mode used for resolving conflicts while performing DDNS updates.
-            
-            Valid values are:
-            * I(check)withI(dhcid): It includes adding a DHCID record and checking that record via conflict detection as per RFC 4703.
-            * I(no)checkI(with)dhcid_: This will ignore conflict detection but add a DHCID record when creating/updating an entry.
-            * I(check)existsI(with)dhcid_: This will check if there is an existing DHCID record but does not verify the value of the record matches the update. This will also update the DHCID record for the entry.
-            * I(no)checkI(without)dhcid_: This ignores conflict detection and will not add a DHCID record when creating/updating a DDNS entry.
-            
-            Defaults to I(check)withI(dhcid).
+        description:
+            - "The mode used for resolving conflicts while performing DDNS updates."
+            - "Valid values are:"
+            - "* I(check_with_dhcid): It includes adding a DHCID record and checking that record via conflict detection as per RFC 4703."
+            - "* I(no_check_with_dhcid): This will ignore conflict detection but add a DHCID record when creating/updating an entry."
+            - "* I(check_exists_with_dhcid): This will check if there is an existing DHCID record but does not verify the value of the record matches the update. This will also update the DHCID record for the entry."
+            - "* I(no_check_without_dhcid): This ignores conflict detection and will not add a DHCID record when creating/updating a DDNS entry."
+            - "Defaults to I(check_with_dhcid)."
         type: str
     ddns_domain:
-        description: >
-            The domain suffix for DDNS updates. FQDN, may be empty.
-            
-            Defaults to empty.
+        description:
+            - "The domain suffix for DDNS updates. FQDN, may be empty."
+            - "Defaults to empty."
         type: str
     ddns_generate_name:
-        description: >
-            Indicates if DDNS needs to generate a hostname when not supplied by the client.
-            
-            Defaults to I(false).
+        description:
+            - "Indicates if DDNS needs to generate a hostname when not supplied by the client."
+            - "Defaults to I(false)."
         type: bool
     ddns_generated_prefix:
-        description: >
-            The prefix used in the generation of an FQDN.
-            
-            When generating a name, DHCP server will construct the name in the format: [ddns-generated-prefix]-[address-text].[ddns-qualifying-suffix].
-            where address-text is simply the lease IP address converted to a hyphenated string.
-            
-            Defaults to "myhost".
+        description:
+            - "The prefix used in the generation of an FQDN."
+            - "When generating a name, DHCP server will construct the name in the format: [ddns-generated-prefix]-[address-text].[ddns-qualifying-suffix]. where address-text is simply the lease IP address converted to a hyphenated string."
+            - "Defaults to &quot;myhost&quot;."
         type: str
     ddns_send_updates:
-        description: >
-            Determines if DDNS updates are enabled at the IP space level.
-            Defaults to I(true).
+        description:
+            - "Determines if DDNS updates are enabled at the IP space level. Defaults to I(true)."
         type: bool
     ddns_ttl_percent:
-        description: >
-            DDNS TTL value - to be calculated as a simple percentage of the lease's lifetime, using the parameter's value as the percentage.
-            It is specified as a percentage (e.g. 25, 75).
-            Defaults to unspecified.
+        description:
+            - "DDNS TTL value - to be calculated as a simple percentage of the lease&#x27;s lifetime, using the parameter&#x27;s value as the percentage. It is specified as a percentage (e.g. 25, 75). Defaults to unspecified."
         type: float
     ddns_update_on_renew:
-        description: >
-            Instructs the DHCP server to always update the DNS information when a lease is renewed even if its DNS information has not changed.
-            
-            Defaults to I(false).
+        description:
+            - "Instructs the DHCP server to always update the DNS information when a lease is renewed even if its DNS information has not changed."
+            - "Defaults to I(false)."
         type: bool
     ddns_use_conflict_resolution:
-        description: >
-            When true, DHCP server will apply conflict resolution, as described in RFC 4703, when attempting to fulfill the update request.
-            
-            When false, DHCP server will simply attempt to update the DNS entries per the request, regardless of whether or not they conflict with existing entries owned by other DHCP4 clients.
-            
-            Defaults to I(true).
+        description:
+            - "When true, DHCP server will apply conflict resolution, as described in RFC 4703, when attempting to fulfill the update request."
+            - "When false, DHCP server will simply attempt to update the DNS entries per the request, regardless of whether or not they conflict with existing entries owned by other DHCP4 clients."
+            - "Defaults to I(true)."
         type: bool
     dhcp_config:
-        description: >
-            The shared DHCP configuration for the IP space that controls how leases are issued.
+        description:
+            - "The shared DHCP configuration for the IP space that controls how leases are issued."
         type: dict
         suboptions:
             abandoned_reclaim_time:
-                description: >
-                    The abandoned reclaim time in seconds for IPV4 clients.
+                description:
+                    - "The abandoned reclaim time in seconds for IPV4 clients."
                 type: int
             abandoned_reclaim_time_v6:
-                description: >
-                    The abandoned reclaim time in seconds for IPV6 clients.
+                description:
+                    - "The abandoned reclaim time in seconds for IPV6 clients."
                 type: int
             allow_unknown:
-                description: >
-                    Disable to allow leases only for known IPv4 clients, those for which a fixed address is configured.
+                description:
+                    - "Disable to allow leases only for known IPv4 clients, those for which a fixed address is configured."
                 type: bool
             allow_unknown_v6:
-                description: >
-                    Disable to allow leases only for known IPV6 clients, those for which a fixed address is configured.
+                description:
+                    - "Disable to allow leases only for known IPV6 clients, those for which a fixed address is configured."
                 type: bool
             echo_client_id:
-                description: >
-                    Enable/disable to include/exclude the client id when responding to discover or request.
+                description:
+                    - "Enable/disable to include/exclude the client id when responding to discover or request."
                 type: bool
             filters:
-                description: >
-                    The resource identifier.
+                description:
+                    - "The resource identifier."
                 type: list
                 elements: str
             filters_v6:
-                description: >
-                    The resource identifier.
+                description:
+                    - "The resource identifier."
                 type: list
                 elements: str
             ignore_client_uid:
-                description: >
-                    Enable to ignore the client UID when issuing a DHCP lease. Use this option to prevent assigning two IP addresses for a client which does not have a UID during one phase of PXE boot but acquires one for the other phase.
+                description:
+                    - "Enable to ignore the client UID when issuing a DHCP lease. Use this option to prevent assigning two IP addresses for a client which does not have a UID during one phase of PXE boot but acquires one for the other phase."
                 type: bool
             ignore_list:
-                description: >
-                    The list of clients to ignore requests from.
+                description:
+                    - "The list of clients to ignore requests from."
                 type: list
                 elements: dict
                 suboptions:
                     type:
-                        description: >
-                            Type of ignore matching: client to ignore by client identifier (client hex or client text) or hardware to ignore by hardware identifier (MAC address). It can have one of the following values:
-                            * I(client)hex_,
-                            * I(client)text_,
-                            * I(hardware).
+                        description:
+                            - "Type of ignore matching: client to ignore by client identifier (client hex or client text) or hardware to ignore by hardware identifier (MAC address). It can have one of the following values:"
+                            - "* I(client_hex),"
+                            - "* I(client_text),"
+                            - "* I(hardware)."
                         type: str
                     value:
-                        description: >
-                            Value to match.
+                        description:
+                            - "Value to match."
                         type: str
             lease_time:
-                description: >
-                    The lease duration in seconds.
+                description:
+                    - "The lease duration in seconds."
                 type: int
             lease_time_v6:
-                description: >
-                    The lease duration in seconds for IPV6 clients.
+                description:
+                    - "The lease duration in seconds for IPV6 clients."
                 type: int
     dhcp_options:
-        description: >
-            The list of IPv4 DHCP options for IP space. May be either a specific option or a group of options.
+        description:
+            - "The list of IPv4 DHCP options for IP space. May be either a specific option or a group of options."
         type: list
         elements: dict
         suboptions:
             group:
-                description: >
-                    The resource identifier.
+                description:
+                    - "The resource identifier."
                 type: str
             option_code:
-                description: >
-                    The resource identifier.
+                description:
+                    - "The resource identifier."
                 type: str
             option_value:
-                description: >
-                    The option value.
+                description:
+                    - "The option value."
                 type: str
             type:
-                description: >
-                    The type of item.
-                    
-                    Valid values are:
-                    * I(group)
-                    * I(option)
+                description:
+                    - "The type of item."
+                    - "Valid values are:"
+                    - "* I(group)"
+                    - "* I(option)"
                 type: str
     dhcp_options_v6:
-        description: >
-            The list of IPv6 DHCP options for IP space. May be either a specific option or a group of options.
+        description:
+            - "The list of IPv6 DHCP options for IP space. May be either a specific option or a group of options."
         type: list
         elements: dict
         suboptions:
             group:
-                description: >
-                    The resource identifier.
+                description:
+                    - "The resource identifier."
                 type: str
             option_code:
-                description: >
-                    The resource identifier.
+                description:
+                    - "The resource identifier."
                 type: str
             option_value:
-                description: >
-                    The option value.
+                description:
+                    - "The option value."
                 type: str
             type:
-                description: >
-                    The type of item.
-                    
-                    Valid values are:
-                    * I(group)
-                    * I(option)
+                description:
+                    - "The type of item."
+                    - "Valid values are:"
+                    - "* I(group)"
+                    - "* I(option)"
                 type: str
     header_option_filename:
-        description: >
-            The configuration for header option filename field.
+        description:
+            - "The configuration for header option filename field."
         type: str
     header_option_server_address:
-        description: >
-            The configuration for header option server address field.
+        description:
+            - "The configuration for header option server address field."
         type: str
     header_option_server_name:
-        description: >
-            The configuration for header option server name field.
+        description:
+            - "The configuration for header option server name field."
         type: str
     hostname_rewrite_char:
-        description: >
-            The character to replace non-matching characters with, when hostname rewrite is enabled.
-            
-            Any single ASCII character or no character if the invalid characters should be removed without replacement.
-            
-            Defaults to "-".
+        description:
+            - "The character to replace non-matching characters with, when hostname rewrite is enabled."
+            - "Any single ASCII character or no character if the invalid characters should be removed without replacement."
+            - "Defaults to &quot;-&quot;."
         type: str
     hostname_rewrite_enabled:
-        description: >
-            Indicates if client supplied hostnames will be rewritten prior to DDNS update by replacing every character that does not match I(hostname)rewriteI(regex) by I(hostname)rewriteI(char).
-            
-            Defaults to I(false).
+        description:
+            - "Indicates if client supplied hostnames will be rewritten prior to DDNS update by replacing every character that does not match I(hostname_rewrite_regex) by I(hostname_rewrite_char)."
+            - "Defaults to I(false)."
         type: bool
     hostname_rewrite_regex:
-        description: >
-            The regex bracket expression to match valid characters.
-            
-            Must begin with "[" and end with "]" and be a compilable POSIX regex.
-            
-            Defaults to "[^a-zA-Z0-9_.]".
+        description:
+            - "The regex bracket expression to match valid characters."
+            - "Must begin with &quot;[&quot; and end with &quot;]&quot; and be a compilable POSIX regex."
+            - "Defaults to &quot;[^a-zA-Z0-9_.]&quot;."
         type: str
     inheritance_sources:
-        description: >
-            The inheritance configuration.
+        description:
+            - "The inheritance configuration."
         type: dict
         suboptions:
             asm_config:
-                description: >
-                    The inheritance configuration for I(asm)config_ field.
+                description:
+                    - "The inheritance configuration for I(asm_config) field."
                 type: dict
                 suboptions:
                     asm_enable_block:
-                        description: >
-                            The block of ASM fields: I(enable), I(enable)notificationI(, )reenableI(date).
+                        description:
+                            - "The block of ASM fields: I(enable), I(enable_notification), I(reenable_date)."
                         type: dict
                         suboptions:
                             action:
-                                description: >
-                                    The inheritance setting.
-                                    
-                                    Valid values are:
-                                    * I(inherit): Use the inherited value.
-                                    * I(override): Use the value set in the object.
-                                    
-                                    Defaults to I(inherit).
+                                description:
+                                    - "The inheritance setting."
+                                    - "Valid values are:"
+                                    - "* I(inherit): Use the inherited value."
+                                    - "* I(override): Use the value set in the object."
+                                    - "Defaults to I(inherit)."
                                 type: str
                     asm_growth_block:
-                        description: >
-                            The block of ASM fields: I(growth)factorI(, )growthI(type).
+                        description:
+                            - "The block of ASM fields: I(growth_factor), I(growth_type)."
                         type: dict
                         suboptions:
                             action:
-                                description: >
-                                    The inheritance setting.
-                                    
-                                    Valid values are:
-                                    * I(inherit): Use the inherited value.
-                                    * I(override): Use the value set in the object.
-                                    
-                                    Defaults to I(inherit).
+                                description:
+                                    - "The inheritance setting."
+                                    - "Valid values are:"
+                                    - "* I(inherit): Use the inherited value."
+                                    - "* I(override): Use the value set in the object."
+                                    - "Defaults to I(inherit)."
                                 type: str
                     asm_threshold:
-                        description: >
-                            ASM shows the number of addresses forecast to be used I(forecast)periodI( days in the future, if it is greater than )asmI(threshold)percentI( * )dhcpI(total) (see I(dhcp)utilization_) then the subnet is flagged.
+                        description:
+                            - "ASM shows the number of addresses forecast to be used I(forecast_period) days in the future, if it is greater than I(asm_threshold_percent) * I(dhcp_total) (see I(dhcp_utilization)) then the subnet is flagged."
                         type: dict
                         suboptions:
                             action:
-                                description: >
-                                    The inheritance setting for a field.
-                                    
-                                    Valid values are:
-                                    * I(inherit): Use the inherited value.
-                                    * I(override): Use the value set in the object.
-                                    
-                                    Defaults to I(inherit).
+                                description:
+                                    - "The inheritance setting for a field."
+                                    - "Valid values are:"
+                                    - "* I(inherit): Use the inherited value."
+                                    - "* I(override): Use the value set in the object."
+                                    - "Defaults to I(inherit)."
                                 type: str
                     forecast_period:
-                        description: >
-                            The forecast period in days.
+                        description:
+                            - "The forecast period in days."
                         type: dict
                         suboptions:
                             action:
-                                description: >
-                                    The inheritance setting for a field.
-                                    
-                                    Valid values are:
-                                    * I(inherit): Use the inherited value.
-                                    * I(override): Use the value set in the object.
-                                    
-                                    Defaults to I(inherit).
+                                description:
+                                    - "The inheritance setting for a field."
+                                    - "Valid values are:"
+                                    - "* I(inherit): Use the inherited value."
+                                    - "* I(override): Use the value set in the object."
+                                    - "Defaults to I(inherit)."
                                 type: str
                     history:
-                        description: >
-                            The minimum amount of history needed before ASM can run on this subnet.
+                        description:
+                            - "The minimum amount of history needed before ASM can run on this subnet."
                         type: dict
                         suboptions:
                             action:
-                                description: >
-                                    The inheritance setting for a field.
-                                    
-                                    Valid values are:
-                                    * I(inherit): Use the inherited value.
-                                    * I(override): Use the value set in the object.
-                                    
-                                    Defaults to I(inherit).
+                                description:
+                                    - "The inheritance setting for a field."
+                                    - "Valid values are:"
+                                    - "* I(inherit): Use the inherited value."
+                                    - "* I(override): Use the value set in the object."
+                                    - "Defaults to I(inherit)."
                                 type: str
                     min_total:
-                        description: >
-                            The minimum size of range needed for ASM to run on this subnet.
+                        description:
+                            - "The minimum size of range needed for ASM to run on this subnet."
                         type: dict
                         suboptions:
                             action:
-                                description: >
-                                    The inheritance setting for a field.
-                                    
-                                    Valid values are:
-                                    * I(inherit): Use the inherited value.
-                                    * I(override): Use the value set in the object.
-                                    
-                                    Defaults to I(inherit).
+                                description:
+                                    - "The inheritance setting for a field."
+                                    - "Valid values are:"
+                                    - "* I(inherit): Use the inherited value."
+                                    - "* I(override): Use the value set in the object."
+                                    - "Defaults to I(inherit)."
                                 type: str
                     min_unused:
-                        description: >
-                            The minimum percentage of addresses that must be available outside of the DHCP ranges and fixed addresses when making a suggested change.
+                        description:
+                            - "The minimum percentage of addresses that must be available outside of the DHCP ranges and fixed addresses when making a suggested change."
                         type: dict
                         suboptions:
                             action:
-                                description: >
-                                    The inheritance setting for a field.
-                                    
-                                    Valid values are:
-                                    * I(inherit): Use the inherited value.
-                                    * I(override): Use the value set in the object.
-                                    
-                                    Defaults to I(inherit).
+                                description:
+                                    - "The inheritance setting for a field."
+                                    - "Valid values are:"
+                                    - "* I(inherit): Use the inherited value."
+                                    - "* I(override): Use the value set in the object."
+                                    - "Defaults to I(inherit)."
                                 type: str
             ddns_client_update:
-                description: >
-                    The inheritance configuration for I(ddns)clientI(update) field from I(IPSpace) object.
+                description:
+                    - "The inheritance configuration for I(ddns_client_update) field from I(IPSpace) object."
                 type: dict
                 suboptions:
                     action:
-                        description: >
-                            The inheritance setting for a field.
-                            
-                            Valid values are:
-                            * I(inherit): Use the inherited value.
-                            * I(override): Use the value set in the object.
-                            
-                            Defaults to I(inherit).
+                        description:
+                            - "The inheritance setting for a field."
+                            - "Valid values are:"
+                            - "* I(inherit): Use the inherited value."
+                            - "* I(override): Use the value set in the object."
+                            - "Defaults to I(inherit)."
                         type: str
             ddns_conflict_resolution_mode:
-                description: >
-                    The inheritance configuration for I(ddns)conflictI(resolution)modeI( field from )IPSpace_ object.
+                description:
+                    - "The inheritance configuration for I(ddns_conflict_resolution_mode) field from I(IPSpace) object."
                 type: dict
                 suboptions:
                     action:
-                        description: >
-                            The inheritance setting for a field.
-                            
-                            Valid values are:
-                            * I(inherit): Use the inherited value.
-                            * I(override): Use the value set in the object.
-                            
-                            Defaults to I(inherit).
+                        description:
+                            - "The inheritance setting for a field."
+                            - "Valid values are:"
+                            - "* I(inherit): Use the inherited value."
+                            - "* I(override): Use the value set in the object."
+                            - "Defaults to I(inherit)."
                         type: str
             ddns_enabled:
-                description: >
-                    The inheritance configuration for I(ddns)enabled_ field. Only action allowed is 'inherit'.
+                description:
+                    - "The inheritance configuration for I(ddns_enabled) field. Only action allowed is &#x27;inherit&#x27;."
                 type: dict
                 suboptions:
                     action:
-                        description: >
-                            The inheritance setting for a field.
-                            
-                            Valid values are:
-                            * I(inherit): Use the inherited value.
-                            * I(override): Use the value set in the object.
-                            
-                            Defaults to I(inherit).
+                        description:
+                            - "The inheritance setting for a field."
+                            - "Valid values are:"
+                            - "* I(inherit): Use the inherited value."
+                            - "* I(override): Use the value set in the object."
+                            - "Defaults to I(inherit)."
                         type: str
             ddns_hostname_block:
-                description: >
-                    The inheritance configuration for I(ddns)generateI(name) and I(ddns)generatedI(prefix) fields from I(IPSpace) object.
+                description:
+                    - "The inheritance configuration for I(ddns_generate_name) and I(ddns_generated_prefix) fields from I(IPSpace) object."
                 type: dict
                 suboptions:
                     action:
-                        description: >
-                            The inheritance setting.
-                            
-                            Valid values are:
-                            * I(inherit): Use the inherited value.
-                            * I(override): Use the value set in the object.
-                            
-                            Defaults to I(inherit).
+                        description:
+                            - "The inheritance setting."
+                            - "Valid values are:"
+                            - "* I(inherit): Use the inherited value."
+                            - "* I(override): Use the value set in the object."
+                            - "Defaults to I(inherit)."
                         type: str
             ddns_ttl_percent:
-                description: >
-                    The inheritance configuration for I(ddns)ttlI(percent) field from I(IPSpace) object.
+                description:
+                    - "The inheritance configuration for I(ddns_ttl_percent) field from I(IPSpace) object."
                 type: dict
                 suboptions:
                     action:
-                        description: >
-                            The inheritance setting for a field.
-                            
-                            Valid values are:
-                            * I(inherit): Use the inherited value.
-                            * I(override): Use the value set in the object.
-                            
-                            Defaults to I(inherit).
+                        description:
+                            - "The inheritance setting for a field."
+                            - "Valid values are:"
+                            - "* I(inherit): Use the inherited value."
+                            - "* I(override): Use the value set in the object."
+                            - "Defaults to I(inherit)."
                         type: str
             ddns_update_block:
-                description: >
-                    The inheritance configuration for I(ddns)sendI(updates) and I(ddns)domainI( fields from )IPSpace_ object.
+                description:
+                    - "The inheritance configuration for I(ddns_send_updates) and I(ddns_domain) fields from I(IPSpace) object."
                 type: dict
                 suboptions:
                     action:
-                        description: >
-                            The inheritance setting.
-                            
-                            Valid values are:
-                            * I(inherit): Use the inherited value.
-                            * I(override): Use the value set in the object.
-                            
-                            Defaults to I(inherit).
+                        description:
+                            - "The inheritance setting."
+                            - "Valid values are:"
+                            - "* I(inherit): Use the inherited value."
+                            - "* I(override): Use the value set in the object."
+                            - "Defaults to I(inherit)."
                         type: str
             ddns_update_on_renew:
-                description: >
-                    The inheritance configuration for I(ddns)updateI(on)renewI( field from )IPSpace_ object.
+                description:
+                    - "The inheritance configuration for I(ddns_update_on_renew) field from I(IPSpace) object."
                 type: dict
                 suboptions:
                     action:
-                        description: >
-                            The inheritance setting for a field.
-                            
-                            Valid values are:
-                            * I(inherit): Use the inherited value.
-                            * I(override): Use the value set in the object.
-                            
-                            Defaults to I(inherit).
+                        description:
+                            - "The inheritance setting for a field."
+                            - "Valid values are:"
+                            - "* I(inherit): Use the inherited value."
+                            - "* I(override): Use the value set in the object."
+                            - "Defaults to I(inherit)."
                         type: str
             ddns_use_conflict_resolution:
-                description: >
-                    The inheritance configuration for I(ddns)useI(conflict)resolutionI( field from )IPSpace_ object.
+                description:
+                    - "The inheritance configuration for I(ddns_use_conflict_resolution) field from I(IPSpace) object."
                 type: dict
                 suboptions:
                     action:
-                        description: >
-                            The inheritance setting for a field.
-                            
-                            Valid values are:
-                            * I(inherit): Use the inherited value.
-                            * I(override): Use the value set in the object.
-                            
-                            Defaults to I(inherit).
+                        description:
+                            - "The inheritance setting for a field."
+                            - "Valid values are:"
+                            - "* I(inherit): Use the inherited value."
+                            - "* I(override): Use the value set in the object."
+                            - "Defaults to I(inherit)."
                         type: str
             dhcp_config:
-                description: >
-                    The inheritance configuration for I(dhcp)config_ field.
+                description:
+                    - "The inheritance configuration for I(dhcp_config) field."
                 type: dict
                 suboptions:
                     abandoned_reclaim_time:
-                        description: >
-                            The inheritance configuration for I(abandoned)reclaimI(time) field from I(DHCPConfig) object.
+                        description:
+                            - "The inheritance configuration for I(abandoned_reclaim_time) field from I(DHCPConfig) object."
                         type: dict
                         suboptions:
                             action:
-                                description: >
-                                    The inheritance setting for a field.
-                                    
-                                    Valid values are:
-                                    * I(inherit): Use the inherited value.
-                                    * I(override): Use the value set in the object.
-                                    
-                                    Defaults to I(inherit).
+                                description:
+                                    - "The inheritance setting for a field."
+                                    - "Valid values are:"
+                                    - "* I(inherit): Use the inherited value."
+                                    - "* I(override): Use the value set in the object."
+                                    - "Defaults to I(inherit)."
                                 type: str
                     abandoned_reclaim_time_v6:
-                        description: >
-                            The inheritance configuration for I(abandoned)reclaimI(time)v6I( field from )DHCPConfig_ object.
+                        description:
+                            - "The inheritance configuration for I(abandoned_reclaim_time_v6) field from I(DHCPConfig) object."
                         type: dict
                         suboptions:
                             action:
-                                description: >
-                                    The inheritance setting for a field.
-                                    
-                                    Valid values are:
-                                    * I(inherit): Use the inherited value.
-                                    * I(override): Use the value set in the object.
-                                    
-                                    Defaults to I(inherit).
+                                description:
+                                    - "The inheritance setting for a field."
+                                    - "Valid values are:"
+                                    - "* I(inherit): Use the inherited value."
+                                    - "* I(override): Use the value set in the object."
+                                    - "Defaults to I(inherit)."
                                 type: str
                     allow_unknown:
-                        description: >
-                            The inheritance configuration for I(allow)unknownI( field from )DHCPConfig_ object.
+                        description:
+                            - "The inheritance configuration for I(allow_unknown) field from I(DHCPConfig) object."
                         type: dict
                         suboptions:
                             action:
-                                description: >
-                                    The inheritance setting for a field.
-                                    
-                                    Valid values are:
-                                    * I(inherit): Use the inherited value.
-                                    * I(override): Use the value set in the object.
-                                    
-                                    Defaults to I(inherit).
+                                description:
+                                    - "The inheritance setting for a field."
+                                    - "Valid values are:"
+                                    - "* I(inherit): Use the inherited value."
+                                    - "* I(override): Use the value set in the object."
+                                    - "Defaults to I(inherit)."
                                 type: str
                     allow_unknown_v6:
-                        description: >
-                            The inheritance configuration for I(allow)unknownI(v6) field from I(DHCPConfig) object.
+                        description:
+                            - "The inheritance configuration for I(allow_unknown_v6) field from I(DHCPConfig) object."
                         type: dict
                         suboptions:
                             action:
-                                description: >
-                                    The inheritance setting for a field.
-                                    
-                                    Valid values are:
-                                    * I(inherit): Use the inherited value.
-                                    * I(override): Use the value set in the object.
-                                    
-                                    Defaults to I(inherit).
+                                description:
+                                    - "The inheritance setting for a field."
+                                    - "Valid values are:"
+                                    - "* I(inherit): Use the inherited value."
+                                    - "* I(override): Use the value set in the object."
+                                    - "Defaults to I(inherit)."
                                 type: str
                     echo_client_id:
-                        description: >
-                            The inheritance configuration for I(echo)clientI(id) field from I(DHCPConfig) object.
+                        description:
+                            - "The inheritance configuration for I(echo_client_id) field from I(DHCPConfig) object."
                         type: dict
                         suboptions:
                             action:
-                                description: >
-                                    The inheritance setting for a field.
-                                    
-                                    Valid values are:
-                                    * I(inherit): Use the inherited value.
-                                    * I(override): Use the value set in the object.
-                                    
-                                    Defaults to I(inherit).
+                                description:
+                                    - "The inheritance setting for a field."
+                                    - "Valid values are:"
+                                    - "* I(inherit): Use the inherited value."
+                                    - "* I(override): Use the value set in the object."
+                                    - "Defaults to I(inherit)."
                                 type: str
                     filters:
-                        description: >
-                            The inheritance configuration for filters field from I(DHCPConfig) object.
+                        description:
+                            - "The inheritance configuration for filters field from I(DHCPConfig) object."
                         type: dict
                         suboptions:
                             action:
-                                description: >
-                                    The inheritance setting.
-                                    
-                                    Valid values are:
-                                    * I(inherit): Use the inherited value.
-                                    * I(override): Use the value set in the object.
-                                    
-                                    Defaults to I(inherit).
+                                description:
+                                    - "The inheritance setting."
+                                    - "Valid values are:"
+                                    - "* I(inherit): Use the inherited value."
+                                    - "* I(override): Use the value set in the object."
+                                    - "Defaults to I(inherit)."
                                 type: str
                             value:
-                                description: >
-                                    The resource identifier.
+                                description:
+                                    - "The resource identifier."
                                 type: list
                                 elements: str
                     filters_v6:
-                        description: >
-                            The inheritance configuration for I(filters)v6I( field from )DHCPConfig_ object.
+                        description:
+                            - "The inheritance configuration for I(filters_v6) field from I(DHCPConfig) object."
                         type: dict
                         suboptions:
                             action:
-                                description: >
-                                    The inheritance setting.
-                                    
-                                    Valid values are:
-                                    * I(inherit): Use the inherited value.
-                                    * I(override): Use the value set in the object.
-                                    
-                                    Defaults to I(inherit).
+                                description:
+                                    - "The inheritance setting."
+                                    - "Valid values are:"
+                                    - "* I(inherit): Use the inherited value."
+                                    - "* I(override): Use the value set in the object."
+                                    - "Defaults to I(inherit)."
                                 type: str
                             value:
-                                description: >
-                                    The resource identifier.
+                                description:
+                                    - "The resource identifier."
                                 type: list
                                 elements: str
                     ignore_client_uid:
-                        description: >
-                            The inheritance configuration for I(ignore)clientI(uid) field from I(DHCPConfig) object.
+                        description:
+                            - "The inheritance configuration for I(ignore_client_uid) field from I(DHCPConfig) object."
                         type: dict
                         suboptions:
                             action:
-                                description: >
-                                    The inheritance setting for a field.
-                                    
-                                    Valid values are:
-                                    * I(inherit): Use the inherited value.
-                                    * I(override): Use the value set in the object.
-                                    
-                                    Defaults to I(inherit).
+                                description:
+                                    - "The inheritance setting for a field."
+                                    - "Valid values are:"
+                                    - "* I(inherit): Use the inherited value."
+                                    - "* I(override): Use the value set in the object."
+                                    - "Defaults to I(inherit)."
                                 type: str
                     ignore_list:
-                        description: >
-                            The inheritance configuration for I(ignore)listI( field from )DHCPConfig_ object.
+                        description:
+                            - "The inheritance configuration for I(ignore_list) field from I(DHCPConfig) object."
                         type: dict
                         suboptions:
                             action:
-                                description: >
-                                    The inheritance setting.
-                                    
-                                    Valid values are:
-                                    * I(inherit): Use the inherited value.
-                                    * I(override): Use the value set in the object.
-                                    
-                                    Defaults to I(inherit).
+                                description:
+                                    - "The inheritance setting."
+                                    - "Valid values are:"
+                                    - "* I(inherit): Use the inherited value."
+                                    - "* I(override): Use the value set in the object."
+                                    - "Defaults to I(inherit)."
                                 type: str
                     lease_time:
-                        description: >
-                            The inheritance configuration for I(lease)timeI( field from )DHCPConfig_ object.
+                        description:
+                            - "The inheritance configuration for I(lease_time) field from I(DHCPConfig) object."
                         type: dict
                         suboptions:
                             action:
-                                description: >
-                                    The inheritance setting for a field.
-                                    
-                                    Valid values are:
-                                    * I(inherit): Use the inherited value.
-                                    * I(override): Use the value set in the object.
-                                    
-                                    Defaults to I(inherit).
+                                description:
+                                    - "The inheritance setting for a field."
+                                    - "Valid values are:"
+                                    - "* I(inherit): Use the inherited value."
+                                    - "* I(override): Use the value set in the object."
+                                    - "Defaults to I(inherit)."
                                 type: str
                     lease_time_v6:
-                        description: >
-                            The inheritance configuration for I(lease)timeI(v6) field from I(DHCPConfig) object.
+                        description:
+                            - "The inheritance configuration for I(lease_time_v6) field from I(DHCPConfig) object."
                         type: dict
                         suboptions:
                             action:
-                                description: >
-                                    The inheritance setting for a field.
-                                    
-                                    Valid values are:
-                                    * I(inherit): Use the inherited value.
-                                    * I(override): Use the value set in the object.
-                                    
-                                    Defaults to I(inherit).
+                                description:
+                                    - "The inheritance setting for a field."
+                                    - "Valid values are:"
+                                    - "* I(inherit): Use the inherited value."
+                                    - "* I(override): Use the value set in the object."
+                                    - "Defaults to I(inherit)."
                                 type: str
             dhcp_options:
-                description: >
-                    The inheritance configuration for I(dhcp)options_ field.
+                description:
+                    - "The inheritance configuration for I(dhcp_options) field."
                 type: dict
                 suboptions:
                     action:
-                        description: >
-                            The inheritance setting.
-                            
-                            Valid values are:
-                            * I(inherit): Use the inherited value.
-                            * I(block): Don't use the inherited value.
-                            
-                            Defaults to I(inherit).
+                        description:
+                            - "The inheritance setting."
+                            - "Valid values are:"
+                            - "* I(inherit): Use the inherited value."
+                            - "* I(block): Don&#x27;t use the inherited value."
+                            - "Defaults to I(inherit)."
                         type: str
                     value:
-                        description: >
-                            The inherited DHCP option values.
+                        description:
+                            - "The inherited DHCP option values."
                         type: list
                         elements: dict
                         suboptions:
                             action:
-                                description: >
-                                    The inheritance setting.
-                                    
-                                    Valid values are:
-                                    * I(inherit): Use the inherited value.
-                                    * I(block): Don't use the inherited value.
-                                    
-                                    Defaults to I(inherit).
+                                description:
+                                    - "The inheritance setting."
+                                    - "Valid values are:"
+                                    - "* I(inherit): Use the inherited value."
+                                    - "* I(block): Don&#x27;t use the inherited value."
+                                    - "Defaults to I(inherit)."
                                 type: str
             dhcp_options_v6:
-                description: >
-                    The inheritance configuration for I(dhcp)optionsI(v6) field.
+                description:
+                    - "The inheritance configuration for I(dhcp_options_v6) field."
                 type: dict
                 suboptions:
                     action:
-                        description: >
-                            The inheritance setting.
-                            
-                            Valid values are:
-                            * I(inherit): Use the inherited value.
-                            * I(block): Don't use the inherited value.
-                            
-                            Defaults to I(inherit).
+                        description:
+                            - "The inheritance setting."
+                            - "Valid values are:"
+                            - "* I(inherit): Use the inherited value."
+                            - "* I(block): Don&#x27;t use the inherited value."
+                            - "Defaults to I(inherit)."
                         type: str
                     value:
-                        description: >
-                            The inherited DHCP option values.
+                        description:
+                            - "The inherited DHCP option values."
                         type: list
                         elements: dict
                         suboptions:
                             action:
-                                description: >
-                                    The inheritance setting.
-                                    
-                                    Valid values are:
-                                    * I(inherit): Use the inherited value.
-                                    * I(block): Don't use the inherited value.
-                                    
-                                    Defaults to I(inherit).
+                                description:
+                                    - "The inheritance setting."
+                                    - "Valid values are:"
+                                    - "* I(inherit): Use the inherited value."
+                                    - "* I(block): Don&#x27;t use the inherited value."
+                                    - "Defaults to I(inherit)."
                                 type: str
             header_option_filename:
-                description: >
-                    The inheritance configuration for I(header)optionI(filename) field.
+                description:
+                    - "The inheritance configuration for I(header_option_filename) field."
                 type: dict
                 suboptions:
                     action:
-                        description: >
-                            The inheritance setting for a field.
-                            
-                            Valid values are:
-                            * I(inherit): Use the inherited value.
-                            * I(override): Use the value set in the object.
-                            
-                            Defaults to I(inherit).
+                        description:
+                            - "The inheritance setting for a field."
+                            - "Valid values are:"
+                            - "* I(inherit): Use the inherited value."
+                            - "* I(override): Use the value set in the object."
+                            - "Defaults to I(inherit)."
                         type: str
             header_option_server_address:
-                description: >
-                    The inheritance configuration for I(header)optionI(server)address_ field.
+                description:
+                    - "The inheritance configuration for I(header_option_server_address) field."
                 type: dict
                 suboptions:
                     action:
-                        description: >
-                            The inheritance setting for a field.
-                            
-                            Valid values are:
-                            * I(inherit): Use the inherited value.
-                            * I(override): Use the value set in the object.
-                            
-                            Defaults to I(inherit).
+                        description:
+                            - "The inheritance setting for a field."
+                            - "Valid values are:"
+                            - "* I(inherit): Use the inherited value."
+                            - "* I(override): Use the value set in the object."
+                            - "Defaults to I(inherit)."
                         type: str
             header_option_server_name:
-                description: >
-                    The inheritance configuration for I(header)optionI(server)name_ field.
+                description:
+                    - "The inheritance configuration for I(header_option_server_name) field."
                 type: dict
                 suboptions:
                     action:
-                        description: >
-                            The inheritance setting for a field.
-                            
-                            Valid values are:
-                            * I(inherit): Use the inherited value.
-                            * I(override): Use the value set in the object.
-                            
-                            Defaults to I(inherit).
+                        description:
+                            - "The inheritance setting for a field."
+                            - "Valid values are:"
+                            - "* I(inherit): Use the inherited value."
+                            - "* I(override): Use the value set in the object."
+                            - "Defaults to I(inherit)."
                         type: str
             hostname_rewrite_block:
-                description: >
-                    The inheritance configuration for I(hostname)rewriteI(enabled), I(hostname)rewriteI(regex), and I(hostname)rewriteI(char) fields from I(IPSpace) object.
+                description:
+                    - "The inheritance configuration for I(hostname_rewrite_enabled), I(hostname_rewrite_regex), and I(hostname_rewrite_char) fields from I(IPSpace) object."
                 type: dict
                 suboptions:
                     action:
-                        description: >
-                            The inheritance setting.
-                            
-                            Valid values are:
-                            * I(inherit): Use the inherited value.
-                            * I(override): Use the value set in the object.
-                            
-                            Defaults to I(inherit).
+                        description:
+                            - "The inheritance setting."
+                            - "Valid values are:"
+                            - "* I(inherit): Use the inherited value."
+                            - "* I(override): Use the value set in the object."
+                            - "Defaults to I(inherit)."
                         type: str
             vendor_specific_option_option_space:
-                description: >
-                    The inheritance configuration for I(vendor)specificI(option)optionI(space) field.
+                description:
+                    - "The inheritance configuration for I(vendor_specific_option_option_space) field."
                 type: dict
                 suboptions:
                     action:
-                        description: >
-                            The inheritance setting for a field.
-                            
-                            Valid values are:
-                            * I(inherit): Use the inherited value.
-                            * I(override): Use the value set in the object.
-                            
-                            Defaults to I(inherit).
+                        description:
+                            - "The inheritance setting for a field."
+                            - "Valid values are:"
+                            - "* I(inherit): Use the inherited value."
+                            - "* I(override): Use the value set in the object."
+                            - "Defaults to I(inherit)."
                         type: str
                     value:
-                        description: >
-                            The resource identifier.
+                        description:
+                            - "The resource identifier."
                         type: str
     name:
-        description: >
-            The name of the IP space. Must contain 1 to 256 characters. Can include UTF-8.
+        description:
+            - "The name of the IP space. Must contain 1 to 256 characters. Can include UTF-8."
         type: str
     tags:
-        description: >
-            The tags for the IP space in JSON format.
+        description:
+            - "The tags for the IP space in JSON format."
         type: dict
     vendor_specific_option_option_space:
-        description: >
-            The resource identifier.
+        description:
+            - "The resource identifier."
         type: str
 
 extends_documentation_fragment:
@@ -904,55 +811,54 @@ item:
     returned: Always
     contains:
         asm_config:
-            description: >
-                The Automated Scope Management configuration for the IP space.
+            description:
+                - "The Automated Scope Management configuration for the IP space."
             type: dict
             returned: Always
             contains:
                 asm_threshold:
-                    description: >
-                        ASM shows the number of addresses forecast to be used I(forecast)periodI( days in the future, if it is greater than )asmI(threshold) percent * I(dhcp)totalI( (see )dhcpI(utilization)) then the subnet is flagged.
+                    description:
+                        - "ASM shows the number of addresses forecast to be used I(forecast_period) days in the future, if it is greater than I(asm_threshold) percent * I(dhcp_total) (see I(dhcp_utilization)) then the subnet is flagged."
                     type: int
                     returned: Always
                 enable:
-                    description: >
-                        Indicates if Automated Scope Management is enabled.
+                    description:
+                        - "Indicates if Automated Scope Management is enabled."
                     type: bool
                     returned: Always
                 enable_notification:
-                    description: >
-                        Indicates if ASM should send notifications to the user.
+                    description:
+                        - "Indicates if ASM should send notifications to the user."
                     type: bool
                     returned: Always
                 forecast_period:
-                    description: >
-                        The forecast period in days.
+                    description:
+                        - "The forecast period in days."
                     type: int
                     returned: Always
                 growth_factor:
-                    description: >
-                        Indicates the growth in the number or percentage of IP addresses.
+                    description:
+                        - "Indicates the growth in the number or percentage of IP addresses."
                     type: int
                     returned: Always
                 growth_type:
-                    description: >
-                        The type of factor to use: I(percent) or I(count).
+                    description:
+                        - "The type of factor to use: I(percent) or I(count)."
                     type: str
                     returned: Always
                 history:
-                    description: >
-                        The minimum amount of history needed before ASM can run on this subnet.
+                    description:
+                        - "The minimum amount of history needed before ASM can run on this subnet."
                     type: int
                     returned: Always
                 min_total:
-                    description: >
-                        The minimum size of range needed for ASM to run on this subnet.
+                    description:
+                        - "The minimum size of range needed for ASM to run on this subnet."
                     type: int
                     returned: Always
                 min_unused:
-                    description: >
-                        The minimum percentage of addresses that must be available outside of the DHCP ranges and fixed addresses
-                        when making a suggested change..
+                    description:
+                        - "The minimum percentage of addresses that must be available outside of the DHCP ranges and fixed addresses when making a suggested change.."
                     type: int
                     returned: Always
                 reenable_date:
@@ -960,1630 +866,1536 @@ item:
                     type: str
                     returned: Always
         asm_scope_flag:
-            description: >
-                The number of times the automated scope management usage limits have been exceeded for any of the subnets in this IP space.
+            description:
+                - "The number of times the automated scope management usage limits have been exceeded for any of the subnets in this IP space."
             type: int
             returned: Always
         comment:
-            description: >
-                The description for the IP space. May contain 0 to 1024 characters. Can include UTF-8.
+            description:
+                - "The description for the IP space. May contain 0 to 1024 characters. Can include UTF-8."
             type: str
             returned: Always
         created_at:
-            description: >
-                Time when the object has been created.
+            description:
+                - "Time when the object has been created."
             type: str
             returned: Always
         ddns_client_update:
-            description: >
-                Controls who does the DDNS updates.
-                
-                Valid values are:
-                * I(client): DHCP server updates DNS if requested by client.
-                * I(server): DHCP server always updates DNS, overriding an update request from the client, unless the client requests no updates.
-                * I(ignore): DHCP server always updates DNS, even if the client says not to.
-                * I(over)clientI(update): Same as I(server). DHCP server always updates DNS, overriding an update request from the client, unless the client requests no updates.
-                * I(over)noI(update): DHCP server updates DNS even if the client requests that no updates be done. If the client requests to do the update, DHCP server allows it.
-                
-                Defaults to I(client).
+            description:
+                - "Controls who does the DDNS updates."
+                - "Valid values are:"
+                - "* I(client): DHCP server updates DNS if requested by client."
+                - "* I(server): DHCP server always updates DNS, overriding an update request from the client, unless the client requests no updates."
+                - "* I(ignore): DHCP server always updates DNS, even if the client says not to."
+                - "* I(over_client_update): Same as I(server). DHCP server always updates DNS, overriding an update request from the client, unless the client requests no updates."
+                - "* I(over_no_update): DHCP server updates DNS even if the client requests that no updates be done. If the client requests to do the update, DHCP server allows it."
+                - "Defaults to I(client)."
             type: str
             returned: Always
         ddns_conflict_resolution_mode:
-            description: >
-                The mode used for resolving conflicts while performing DDNS updates.
-                
-                Valid values are:
-                * I(check)withI(dhcid): It includes adding a DHCID record and checking that record via conflict detection as per RFC 4703.
-                * I(no)checkI(with)dhcid_: This will ignore conflict detection but add a DHCID record when creating/updating an entry.
-                * I(check)existsI(with)dhcid_: This will check if there is an existing DHCID record but does not verify the value of the record matches the update. This will also update the DHCID record for the entry.
-                * I(no)checkI(without)dhcid_: This ignores conflict detection and will not add a DHCID record when creating/updating a DDNS entry.
-                
-                Defaults to I(check)withI(dhcid).
+            description:
+                - "The mode used for resolving conflicts while performing DDNS updates."
+                - "Valid values are:"
+                - "* I(check_with_dhcid): It includes adding a DHCID record and checking that record via conflict detection as per RFC 4703."
+                - "* I(no_check_with_dhcid): This will ignore conflict detection but add a DHCID record when creating/updating an entry."
+                - "* I(check_exists_with_dhcid): This will check if there is an existing DHCID record but does not verify the value of the record matches the update. This will also update the DHCID record for the entry."
+                - "* I(no_check_without_dhcid): This ignores conflict detection and will not add a DHCID record when creating/updating a DDNS entry."
+                - "Defaults to I(check_with_dhcid)."
             type: str
             returned: Always
         ddns_domain:
-            description: >
-                The domain suffix for DDNS updates. FQDN, may be empty.
-                
-                Defaults to empty.
+            description:
+                - "The domain suffix for DDNS updates. FQDN, may be empty."
+                - "Defaults to empty."
             type: str
             returned: Always
         ddns_generate_name:
-            description: >
-                Indicates if DDNS needs to generate a hostname when not supplied by the client.
-                
-                Defaults to I(false).
+            description:
+                - "Indicates if DDNS needs to generate a hostname when not supplied by the client."
+                - "Defaults to I(false)."
             type: bool
             returned: Always
         ddns_generated_prefix:
-            description: >
-                The prefix used in the generation of an FQDN.
-                
-                When generating a name, DHCP server will construct the name in the format: [ddns-generated-prefix]-[address-text].[ddns-qualifying-suffix].
-                where address-text is simply the lease IP address converted to a hyphenated string.
-                
-                Defaults to "myhost".
+            description:
+                - "The prefix used in the generation of an FQDN."
+                - "When generating a name, DHCP server will construct the name in the format: [ddns-generated-prefix]-[address-text].[ddns-qualifying-suffix]. where address-text is simply the lease IP address converted to a hyphenated string."
+                - "Defaults to &quot;myhost&quot;."
             type: str
             returned: Always
         ddns_send_updates:
-            description: >
-                Determines if DDNS updates are enabled at the IP space level.
-                Defaults to I(true).
+            description:
+                - "Determines if DDNS updates are enabled at the IP space level. Defaults to I(true)."
             type: bool
             returned: Always
         ddns_ttl_percent:
-            description: >
-                DDNS TTL value - to be calculated as a simple percentage of the lease's lifetime, using the parameter's value as the percentage.
-                It is specified as a percentage (e.g. 25, 75).
-                Defaults to unspecified.
+            description:
+                - "DDNS TTL value - to be calculated as a simple percentage of the lease&#x27;s lifetime, using the parameter&#x27;s value as the percentage. It is specified as a percentage (e.g. 25, 75). Defaults to unspecified."
             type: float
             returned: Always
         ddns_update_on_renew:
-            description: >
-                Instructs the DHCP server to always update the DNS information when a lease is renewed even if its DNS information has not changed.
-                
-                Defaults to I(false).
+            description:
+                - "Instructs the DHCP server to always update the DNS information when a lease is renewed even if its DNS information has not changed."
+                - "Defaults to I(false)."
             type: bool
             returned: Always
         ddns_use_conflict_resolution:
-            description: >
-                When true, DHCP server will apply conflict resolution, as described in RFC 4703, when attempting to fulfill the update request.
-                
-                When false, DHCP server will simply attempt to update the DNS entries per the request, regardless of whether or not they conflict with existing entries owned by other DHCP4 clients.
-                
-                Defaults to I(true).
+            description:
+                - "When true, DHCP server will apply conflict resolution, as described in RFC 4703, when attempting to fulfill the update request."
+                - "When false, DHCP server will simply attempt to update the DNS entries per the request, regardless of whether or not they conflict with existing entries owned by other DHCP4 clients."
+                - "Defaults to I(true)."
             type: bool
             returned: Always
         dhcp_config:
-            description: >
-                The shared DHCP configuration for the IP space that controls how leases are issued.
+            description:
+                - "The shared DHCP configuration for the IP space that controls how leases are issued."
             type: dict
             returned: Always
             contains:
                 abandoned_reclaim_time:
-                    description: >
-                        The abandoned reclaim time in seconds for IPV4 clients.
+                    description:
+                        - "The abandoned reclaim time in seconds for IPV4 clients."
                     type: int
                     returned: Always
                 abandoned_reclaim_time_v6:
-                    description: >
-                        The abandoned reclaim time in seconds for IPV6 clients.
+                    description:
+                        - "The abandoned reclaim time in seconds for IPV6 clients."
                     type: int
                     returned: Always
                 allow_unknown:
-                    description: >
-                        Disable to allow leases only for known IPv4 clients, those for which a fixed address is configured.
+                    description:
+                        - "Disable to allow leases only for known IPv4 clients, those for which a fixed address is configured."
                     type: bool
                     returned: Always
                 allow_unknown_v6:
-                    description: >
-                        Disable to allow leases only for known IPV6 clients, those for which a fixed address is configured.
+                    description:
+                        - "Disable to allow leases only for known IPV6 clients, those for which a fixed address is configured."
                     type: bool
                     returned: Always
                 echo_client_id:
-                    description: >
-                        Enable/disable to include/exclude the client id when responding to discover or request.
+                    description:
+                        - "Enable/disable to include/exclude the client id when responding to discover or request."
                     type: bool
                     returned: Always
                 filters:
-                    description: >
-                        The resource identifier.
+                    description:
+                        - "The resource identifier."
                     type: list
                     returned: Always
                 filters_v6:
-                    description: >
-                        The resource identifier.
+                    description:
+                        - "The resource identifier."
                     type: list
                     returned: Always
                 ignore_client_uid:
-                    description: >
-                        Enable to ignore the client UID when issuing a DHCP lease. Use this option to prevent assigning two IP addresses for a client which does not have a UID during one phase of PXE boot but acquires one for the other phase.
+                    description:
+                        - "Enable to ignore the client UID when issuing a DHCP lease. Use this option to prevent assigning two IP addresses for a client which does not have a UID during one phase of PXE boot but acquires one for the other phase."
                     type: bool
                     returned: Always
                 ignore_list:
-                    description: >
-                        The list of clients to ignore requests from.
+                    description:
+                        - "The list of clients to ignore requests from."
                     type: list
                     returned: Always
                     elements: dict
                     contains:
                         type:
-                            description: >
-                                Type of ignore matching: client to ignore by client identifier (client hex or client text) or hardware to ignore by hardware identifier (MAC address). It can have one of the following values:
-                                * I(client)hex_,
-                                * I(client)text_,
-                                * I(hardware).
+                            description:
+                                - "Type of ignore matching: client to ignore by client identifier (client hex or client text) or hardware to ignore by hardware identifier (MAC address). It can have one of the following values:"
+                                - "* I(client_hex),"
+                                - "* I(client_text),"
+                                - "* I(hardware)."
                             type: str
                             returned: Always
                         value:
-                            description: >
-                                Value to match.
+                            description:
+                                - "Value to match."
                             type: str
                             returned: Always
                 lease_time:
-                    description: >
-                        The lease duration in seconds.
+                    description:
+                        - "The lease duration in seconds."
                     type: int
                     returned: Always
                 lease_time_v6:
-                    description: >
-                        The lease duration in seconds for IPV6 clients.
+                    description:
+                        - "The lease duration in seconds for IPV6 clients."
                     type: int
                     returned: Always
         dhcp_options:
-            description: >
-                The list of IPv4 DHCP options for IP space. May be either a specific option or a group of options.
+            description:
+                - "The list of IPv4 DHCP options for IP space. May be either a specific option or a group of options."
             type: list
             returned: Always
             elements: dict
             contains:
                 group:
-                    description: >
-                        The resource identifier.
+                    description:
+                        - "The resource identifier."
                     type: str
                     returned: Always
                 option_code:
-                    description: >
-                        The resource identifier.
+                    description:
+                        - "The resource identifier."
                     type: str
                     returned: Always
                 option_value:
-                    description: >
-                        The option value.
+                    description:
+                        - "The option value."
                     type: str
                     returned: Always
                 type:
-                    description: >
-                        The type of item.
-                        
-                        Valid values are:
-                        * I(group)
-                        * I(option)
+                    description:
+                        - "The type of item."
+                        - "Valid values are:"
+                        - "* I(group)"
+                        - "* I(option)"
                     type: str
                     returned: Always
         dhcp_options_v6:
-            description: >
-                The list of IPv6 DHCP options for IP space. May be either a specific option or a group of options.
+            description:
+                - "The list of IPv6 DHCP options for IP space. May be either a specific option or a group of options."
             type: list
             returned: Always
             elements: dict
             contains:
                 group:
-                    description: >
-                        The resource identifier.
+                    description:
+                        - "The resource identifier."
                     type: str
                     returned: Always
                 option_code:
-                    description: >
-                        The resource identifier.
+                    description:
+                        - "The resource identifier."
                     type: str
                     returned: Always
                 option_value:
-                    description: >
-                        The option value.
+                    description:
+                        - "The option value."
                     type: str
                     returned: Always
                 type:
-                    description: >
-                        The type of item.
-                        
-                        Valid values are:
-                        * I(group)
-                        * I(option)
+                    description:
+                        - "The type of item."
+                        - "Valid values are:"
+                        - "* I(group)"
+                        - "* I(option)"
                     type: str
                     returned: Always
         header_option_filename:
-            description: >
-                The configuration for header option filename field.
+            description:
+                - "The configuration for header option filename field."
             type: str
             returned: Always
         header_option_server_address:
-            description: >
-                The configuration for header option server address field.
+            description:
+                - "The configuration for header option server address field."
             type: str
             returned: Always
         header_option_server_name:
-            description: >
-                The configuration for header option server name field.
+            description:
+                - "The configuration for header option server name field."
             type: str
             returned: Always
         hostname_rewrite_char:
-            description: >
-                The character to replace non-matching characters with, when hostname rewrite is enabled.
-                
-                Any single ASCII character or no character if the invalid characters should be removed without replacement.
-                
-                Defaults to "-".
+            description:
+                - "The character to replace non-matching characters with, when hostname rewrite is enabled."
+                - "Any single ASCII character or no character if the invalid characters should be removed without replacement."
+                - "Defaults to &quot;-&quot;."
             type: str
             returned: Always
         hostname_rewrite_enabled:
-            description: >
-                Indicates if client supplied hostnames will be rewritten prior to DDNS update by replacing every character that does not match I(hostname)rewriteI(regex) by I(hostname)rewriteI(char).
-                
-                Defaults to I(false).
+            description:
+                - "Indicates if client supplied hostnames will be rewritten prior to DDNS update by replacing every character that does not match I(hostname_rewrite_regex) by I(hostname_rewrite_char)."
+                - "Defaults to I(false)."
             type: bool
             returned: Always
         hostname_rewrite_regex:
-            description: >
-                The regex bracket expression to match valid characters.
-                
-                Must begin with "[" and end with "]" and be a compilable POSIX regex.
-                
-                Defaults to "[^a-zA-Z0-9_.]".
+            description:
+                - "The regex bracket expression to match valid characters."
+                - "Must begin with &quot;[&quot; and end with &quot;]&quot; and be a compilable POSIX regex."
+                - "Defaults to &quot;[^a-zA-Z0-9_.]&quot;."
             type: str
             returned: Always
         id:
-            description: >
-                The resource identifier.
+            description:
+                - "The resource identifier."
             type: str
             returned: Always
         inheritance_sources:
-            description: >
-                The inheritance configuration.
+            description:
+                - "The inheritance configuration."
             type: dict
             returned: Always
             contains:
                 asm_config:
-                    description: >
-                        The inheritance configuration for I(asm)config_ field.
+                    description:
+                        - "The inheritance configuration for I(asm_config) field."
                     type: dict
                     returned: Always
                     contains:
                         asm_enable_block:
-                            description: >
-                                The block of ASM fields: I(enable), I(enable)notificationI(, )reenableI(date).
+                            description:
+                                - "The block of ASM fields: I(enable), I(enable_notification), I(reenable_date)."
                             type: dict
                             returned: Always
                             contains:
                                 action:
-                                    description: >
-                                        The inheritance setting.
-                                        
-                                        Valid values are:
-                                        * I(inherit): Use the inherited value.
-                                        * I(override): Use the value set in the object.
-                                        
-                                        Defaults to I(inherit).
+                                    description:
+                                        - "The inheritance setting."
+                                        - "Valid values are:"
+                                        - "* I(inherit): Use the inherited value."
+                                        - "* I(override): Use the value set in the object."
+                                        - "Defaults to I(inherit)."
                                     type: str
                                     returned: Always
                                 display_name:
-                                    description: >
-                                        The human-readable display name for the object referred to by I(source).
+                                    description:
+                                        - "The human-readable display name for the object referred to by I(source)."
                                     type: str
                                     returned: Always
                                 source:
-                                    description: >
-                                        The resource identifier.
+                                    description:
+                                        - "The resource identifier."
                                     type: str
                                     returned: Always
                                 value:
-                                    description: >
-                                        The inherited value.
+                                    description:
+                                        - "The inherited value."
                                     type: dict
                                     returned: Always
                                     contains:
                                         enable:
-                                            description: >
-                                                Indicates whether Automated Scope Management is enabled or not.
+                                            description:
+                                                - "Indicates whether Automated Scope Management is enabled or not."
                                             type: bool
                                             returned: Always
                                         enable_notification:
-                                            description: >
-                                                Indicates whether sending notifications to the users is enabled or not.
+                                            description:
+                                                - "Indicates whether sending notifications to the users is enabled or not."
                                             type: bool
                                             returned: Always
                                         reenable_date:
-                                            description: >
-                                                The date at which notifications will be re-enabled automatically.
+                                            description:
+                                                - "The date at which notifications will be re-enabled automatically."
                                             type: str
                                             returned: Always
                         asm_growth_block:
-                            description: >
-                                The block of ASM fields: I(growth)factorI(, )growthI(type).
+                            description:
+                                - "The block of ASM fields: I(growth_factor), I(growth_type)."
                             type: dict
                             returned: Always
                             contains:
                                 action:
-                                    description: >
-                                        The inheritance setting.
-                                        
-                                        Valid values are:
-                                        * I(inherit): Use the inherited value.
-                                        * I(override): Use the value set in the object.
-                                        
-                                        Defaults to I(inherit).
+                                    description:
+                                        - "The inheritance setting."
+                                        - "Valid values are:"
+                                        - "* I(inherit): Use the inherited value."
+                                        - "* I(override): Use the value set in the object."
+                                        - "Defaults to I(inherit)."
                                     type: str
                                     returned: Always
                                 display_name:
-                                    description: >
-                                        The human-readable display name for the object referred to by I(source).
+                                    description:
+                                        - "The human-readable display name for the object referred to by I(source)."
                                     type: str
                                     returned: Always
                                 source:
-                                    description: >
-                                        The resource identifier.
+                                    description:
+                                        - "The resource identifier."
                                     type: str
                                     returned: Always
                                 value:
-                                    description: >
-                                        The inherited value.
+                                    description:
+                                        - "The inherited value."
                                     type: dict
                                     returned: Always
                                     contains:
                                         growth_factor:
-                                            description: >
-                                                Either the number or percentage of addresses to grow by.
+                                            description:
+                                                - "Either the number or percentage of addresses to grow by."
                                             type: int
                                             returned: Always
                                         growth_type:
-                                            description: >
-                                                The type of factor to use: I(percent) or I(count).
+                                            description:
+                                                - "The type of factor to use: I(percent) or I(count)."
                                             type: str
                                             returned: Always
                         asm_threshold:
-                            description: >
-                                ASM shows the number of addresses forecast to be used I(forecast)periodI( days in the future, if it is greater than )asmI(threshold)percentI( * )dhcpI(total) (see I(dhcp)utilization_) then the subnet is flagged.
+                            description:
+                                - "ASM shows the number of addresses forecast to be used I(forecast_period) days in the future, if it is greater than I(asm_threshold_percent) * I(dhcp_total) (see I(dhcp_utilization)) then the subnet is flagged."
                             type: dict
                             returned: Always
                             contains:
                                 action:
-                                    description: >
-                                        The inheritance setting for a field.
-                                        
-                                        Valid values are:
-                                        * I(inherit): Use the inherited value.
-                                        * I(override): Use the value set in the object.
-                                        
-                                        Defaults to I(inherit).
+                                    description:
+                                        - "The inheritance setting for a field."
+                                        - "Valid values are:"
+                                        - "* I(inherit): Use the inherited value."
+                                        - "* I(override): Use the value set in the object."
+                                        - "Defaults to I(inherit)."
                                     type: str
                                     returned: Always
                                 display_name:
-                                    description: >
-                                        The human-readable display name for the object referred to by I(source).
+                                    description:
+                                        - "The human-readable display name for the object referred to by I(source)."
                                     type: str
                                     returned: Always
                                 source:
-                                    description: >
-                                        The resource identifier.
+                                    description:
+                                        - "The resource identifier."
                                     type: str
                                     returned: Always
                                 value:
-                                    description: >
-                                        The inherited value.
+                                    description:
+                                        - "The inherited value."
                                     type: int
                                     returned: Always
                         forecast_period:
-                            description: >
-                                The forecast period in days.
+                            description:
+                                - "The forecast period in days."
                             type: dict
                             returned: Always
                             contains:
                                 action:
-                                    description: >
-                                        The inheritance setting for a field.
-                                        
-                                        Valid values are:
-                                        * I(inherit): Use the inherited value.
-                                        * I(override): Use the value set in the object.
-                                        
-                                        Defaults to I(inherit).
+                                    description:
+                                        - "The inheritance setting for a field."
+                                        - "Valid values are:"
+                                        - "* I(inherit): Use the inherited value."
+                                        - "* I(override): Use the value set in the object."
+                                        - "Defaults to I(inherit)."
                                     type: str
                                     returned: Always
                                 display_name:
-                                    description: >
-                                        The human-readable display name for the object referred to by I(source).
+                                    description:
+                                        - "The human-readable display name for the object referred to by I(source)."
                                     type: str
                                     returned: Always
                                 source:
-                                    description: >
-                                        The resource identifier.
+                                    description:
+                                        - "The resource identifier."
                                     type: str
                                     returned: Always
                                 value:
-                                    description: >
-                                        The inherited value.
+                                    description:
+                                        - "The inherited value."
                                     type: int
                                     returned: Always
                         history:
-                            description: >
-                                The minimum amount of history needed before ASM can run on this subnet.
+                            description:
+                                - "The minimum amount of history needed before ASM can run on this subnet."
                             type: dict
                             returned: Always
                             contains:
                                 action:
-                                    description: >
-                                        The inheritance setting for a field.
-                                        
-                                        Valid values are:
-                                        * I(inherit): Use the inherited value.
-                                        * I(override): Use the value set in the object.
-                                        
-                                        Defaults to I(inherit).
+                                    description:
+                                        - "The inheritance setting for a field."
+                                        - "Valid values are:"
+                                        - "* I(inherit): Use the inherited value."
+                                        - "* I(override): Use the value set in the object."
+                                        - "Defaults to I(inherit)."
                                     type: str
                                     returned: Always
                                 display_name:
-                                    description: >
-                                        The human-readable display name for the object referred to by I(source).
+                                    description:
+                                        - "The human-readable display name for the object referred to by I(source)."
                                     type: str
                                     returned: Always
                                 source:
-                                    description: >
-                                        The resource identifier.
+                                    description:
+                                        - "The resource identifier."
                                     type: str
                                     returned: Always
                                 value:
-                                    description: >
-                                        The inherited value.
+                                    description:
+                                        - "The inherited value."
                                     type: int
                                     returned: Always
                         min_total:
-                            description: >
-                                The minimum size of range needed for ASM to run on this subnet.
+                            description:
+                                - "The minimum size of range needed for ASM to run on this subnet."
                             type: dict
                             returned: Always
                             contains:
                                 action:
-                                    description: >
-                                        The inheritance setting for a field.
-                                        
-                                        Valid values are:
-                                        * I(inherit): Use the inherited value.
-                                        * I(override): Use the value set in the object.
-                                        
-                                        Defaults to I(inherit).
+                                    description:
+                                        - "The inheritance setting for a field."
+                                        - "Valid values are:"
+                                        - "* I(inherit): Use the inherited value."
+                                        - "* I(override): Use the value set in the object."
+                                        - "Defaults to I(inherit)."
                                     type: str
                                     returned: Always
                                 display_name:
-                                    description: >
-                                        The human-readable display name for the object referred to by I(source).
+                                    description:
+                                        - "The human-readable display name for the object referred to by I(source)."
                                     type: str
                                     returned: Always
                                 source:
-                                    description: >
-                                        The resource identifier.
+                                    description:
+                                        - "The resource identifier."
                                     type: str
                                     returned: Always
                                 value:
-                                    description: >
-                                        The inherited value.
+                                    description:
+                                        - "The inherited value."
                                     type: int
                                     returned: Always
                         min_unused:
-                            description: >
-                                The minimum percentage of addresses that must be available outside of the DHCP ranges and fixed addresses when making a suggested change.
+                            description:
+                                - "The minimum percentage of addresses that must be available outside of the DHCP ranges and fixed addresses when making a suggested change."
                             type: dict
                             returned: Always
                             contains:
                                 action:
-                                    description: >
-                                        The inheritance setting for a field.
-                                        
-                                        Valid values are:
-                                        * I(inherit): Use the inherited value.
-                                        * I(override): Use the value set in the object.
-                                        
-                                        Defaults to I(inherit).
+                                    description:
+                                        - "The inheritance setting for a field."
+                                        - "Valid values are:"
+                                        - "* I(inherit): Use the inherited value."
+                                        - "* I(override): Use the value set in the object."
+                                        - "Defaults to I(inherit)."
                                     type: str
                                     returned: Always
                                 display_name:
-                                    description: >
-                                        The human-readable display name for the object referred to by I(source).
+                                    description:
+                                        - "The human-readable display name for the object referred to by I(source)."
                                     type: str
                                     returned: Always
                                 source:
-                                    description: >
-                                        The resource identifier.
+                                    description:
+                                        - "The resource identifier."
                                     type: str
                                     returned: Always
                                 value:
-                                    description: >
-                                        The inherited value.
+                                    description:
+                                        - "The inherited value."
                                     type: int
                                     returned: Always
                 ddns_client_update:
-                    description: >
-                        The inheritance configuration for I(ddns)clientI(update) field from I(IPSpace) object.
+                    description:
+                        - "The inheritance configuration for I(ddns_client_update) field from I(IPSpace) object."
                     type: dict
                     returned: Always
                     contains:
                         action:
-                            description: >
-                                The inheritance setting for a field.
-                                
-                                Valid values are:
-                                * I(inherit): Use the inherited value.
-                                * I(override): Use the value set in the object.
-                                
-                                Defaults to I(inherit).
+                            description:
+                                - "The inheritance setting for a field."
+                                - "Valid values are:"
+                                - "* I(inherit): Use the inherited value."
+                                - "* I(override): Use the value set in the object."
+                                - "Defaults to I(inherit)."
                             type: str
                             returned: Always
                         display_name:
-                            description: >
-                                The human-readable display name for the object referred to by I(source).
+                            description:
+                                - "The human-readable display name for the object referred to by I(source)."
                             type: str
                             returned: Always
                         source:
-                            description: >
-                                The resource identifier.
+                            description:
+                                - "The resource identifier."
                             type: str
                             returned: Always
                         value:
-                            description: >
-                                The inherited value.
+                            description:
+                                - "The inherited value."
                             type: str
                             returned: Always
                 ddns_conflict_resolution_mode:
-                    description: >
-                        The inheritance configuration for I(ddns)conflictI(resolution)modeI( field from )IPSpace_ object.
+                    description:
+                        - "The inheritance configuration for I(ddns_conflict_resolution_mode) field from I(IPSpace) object."
                     type: dict
                     returned: Always
                     contains:
                         action:
-                            description: >
-                                The inheritance setting for a field.
-                                
-                                Valid values are:
-                                * I(inherit): Use the inherited value.
-                                * I(override): Use the value set in the object.
-                                
-                                Defaults to I(inherit).
+                            description:
+                                - "The inheritance setting for a field."
+                                - "Valid values are:"
+                                - "* I(inherit): Use the inherited value."
+                                - "* I(override): Use the value set in the object."
+                                - "Defaults to I(inherit)."
                             type: str
                             returned: Always
                         display_name:
-                            description: >
-                                The human-readable display name for the object referred to by I(source).
+                            description:
+                                - "The human-readable display name for the object referred to by I(source)."
                             type: str
                             returned: Always
                         source:
-                            description: >
-                                The resource identifier.
+                            description:
+                                - "The resource identifier."
                             type: str
                             returned: Always
                         value:
-                            description: >
-                                The inherited value.
+                            description:
+                                - "The inherited value."
                             type: str
                             returned: Always
                 ddns_enabled:
-                    description: >
-                        The inheritance configuration for I(ddns)enabled_ field. Only action allowed is 'inherit'.
+                    description:
+                        - "The inheritance configuration for I(ddns_enabled) field. Only action allowed is &#x27;inherit&#x27;."
                     type: dict
                     returned: Always
                     contains:
                         action:
-                            description: >
-                                The inheritance setting for a field.
-                                
-                                Valid values are:
-                                * I(inherit): Use the inherited value.
-                                * I(override): Use the value set in the object.
-                                
-                                Defaults to I(inherit).
+                            description:
+                                - "The inheritance setting for a field."
+                                - "Valid values are:"
+                                - "* I(inherit): Use the inherited value."
+                                - "* I(override): Use the value set in the object."
+                                - "Defaults to I(inherit)."
                             type: str
                             returned: Always
                         display_name:
-                            description: >
-                                The human-readable display name for the object referred to by I(source).
+                            description:
+                                - "The human-readable display name for the object referred to by I(source)."
                             type: str
                             returned: Always
                         source:
-                            description: >
-                                The resource identifier.
+                            description:
+                                - "The resource identifier."
                             type: str
                             returned: Always
                         value:
-                            description: >
-                                The inherited value.
+                            description:
+                                - "The inherited value."
                             type: bool
                             returned: Always
                 ddns_hostname_block:
-                    description: >
-                        The inheritance configuration for I(ddns)generateI(name) and I(ddns)generatedI(prefix) fields from I(IPSpace) object.
+                    description:
+                        - "The inheritance configuration for I(ddns_generate_name) and I(ddns_generated_prefix) fields from I(IPSpace) object."
                     type: dict
                     returned: Always
                     contains:
                         action:
-                            description: >
-                                The inheritance setting.
-                                
-                                Valid values are:
-                                * I(inherit): Use the inherited value.
-                                * I(override): Use the value set in the object.
-                                
-                                Defaults to I(inherit).
+                            description:
+                                - "The inheritance setting."
+                                - "Valid values are:"
+                                - "* I(inherit): Use the inherited value."
+                                - "* I(override): Use the value set in the object."
+                                - "Defaults to I(inherit)."
                             type: str
                             returned: Always
                         display_name:
-                            description: >
-                                The human-readable display name for the object referred to by I(source).
+                            description:
+                                - "The human-readable display name for the object referred to by I(source)."
                             type: str
                             returned: Always
                         source:
-                            description: >
-                                The resource identifier.
+                            description:
+                                - "The resource identifier."
                             type: str
                             returned: Always
                         value:
-                            description: >
-                                The inherited value.
+                            description:
+                                - "The inherited value."
                             type: dict
                             returned: Always
                             contains:
                                 ddns_generate_name:
-                                    description: >
-                                        Indicates if DDNS should generate a hostname when not supplied by the client.
+                                    description:
+                                        - "Indicates if DDNS should generate a hostname when not supplied by the client."
                                     type: bool
                                     returned: Always
                                 ddns_generated_prefix:
-                                    description: >
-                                        The prefix used in the generation of an FQDN.
+                                    description:
+                                        - "The prefix used in the generation of an FQDN."
                                     type: str
                                     returned: Always
                 ddns_ttl_percent:
-                    description: >
-                        The inheritance configuration for I(ddns)ttlI(percent) field from I(IPSpace) object.
+                    description:
+                        - "The inheritance configuration for I(ddns_ttl_percent) field from I(IPSpace) object."
                     type: dict
                     returned: Always
                     contains:
                         action:
-                            description: >
-                                The inheritance setting for a field.
-                                
-                                Valid values are:
-                                * I(inherit): Use the inherited value.
-                                * I(override): Use the value set in the object.
-                                
-                                Defaults to I(inherit).
+                            description:
+                                - "The inheritance setting for a field."
+                                - "Valid values are:"
+                                - "* I(inherit): Use the inherited value."
+                                - "* I(override): Use the value set in the object."
+                                - "Defaults to I(inherit)."
                             type: str
                             returned: Always
                         display_name:
-                            description: >
-                                The human-readable display name for the object referred to by I(source).
+                            description:
+                                - "The human-readable display name for the object referred to by I(source)."
                             type: str
                             returned: Always
                         source:
-                            description: >
-                                The resource identifier.
+                            description:
+                                - "The resource identifier."
                             type: str
                             returned: Always
                         value:
-                            description: >
-                                The inherited value.
+                            description:
+                                - "The inherited value."
                             type: float
                             returned: Always
                 ddns_update_block:
-                    description: >
-                        The inheritance configuration for I(ddns)sendI(updates) and I(ddns)domainI( fields from )IPSpace_ object.
+                    description:
+                        - "The inheritance configuration for I(ddns_send_updates) and I(ddns_domain) fields from I(IPSpace) object."
                     type: dict
                     returned: Always
                     contains:
                         action:
-                            description: >
-                                The inheritance setting.
-                                
-                                Valid values are:
-                                * I(inherit): Use the inherited value.
-                                * I(override): Use the value set in the object.
-                                
-                                Defaults to I(inherit).
+                            description:
+                                - "The inheritance setting."
+                                - "Valid values are:"
+                                - "* I(inherit): Use the inherited value."
+                                - "* I(override): Use the value set in the object."
+                                - "Defaults to I(inherit)."
                             type: str
                             returned: Always
                         display_name:
-                            description: >
-                                The human-readable display name for the object referred to by I(source).
+                            description:
+                                - "The human-readable display name for the object referred to by I(source)."
                             type: str
                             returned: Always
                         source:
-                            description: >
-                                The resource identifier.
+                            description:
+                                - "The resource identifier."
                             type: str
                             returned: Always
                         value:
-                            description: >
-                                The inherited value.
+                            description:
+                                - "The inherited value."
                             type: dict
                             returned: Always
                             contains:
                                 ddns_domain:
-                                    description: >
-                                        The domain name for DDNS.
+                                    description:
+                                        - "The domain name for DDNS."
                                     type: str
                                     returned: Always
                                 ddns_send_updates:
-                                    description: >
-                                        Determines if DDNS updates are enabled at this level.
+                                    description:
+                                        - "Determines if DDNS updates are enabled at this level."
                                     type: bool
                                     returned: Always
                 ddns_update_on_renew:
-                    description: >
-                        The inheritance configuration for I(ddns)updateI(on)renewI( field from )IPSpace_ object.
+                    description:
+                        - "The inheritance configuration for I(ddns_update_on_renew) field from I(IPSpace) object."
                     type: dict
                     returned: Always
                     contains:
                         action:
-                            description: >
-                                The inheritance setting for a field.
-                                
-                                Valid values are:
-                                * I(inherit): Use the inherited value.
-                                * I(override): Use the value set in the object.
-                                
-                                Defaults to I(inherit).
+                            description:
+                                - "The inheritance setting for a field."
+                                - "Valid values are:"
+                                - "* I(inherit): Use the inherited value."
+                                - "* I(override): Use the value set in the object."
+                                - "Defaults to I(inherit)."
                             type: str
                             returned: Always
                         display_name:
-                            description: >
-                                The human-readable display name for the object referred to by I(source).
+                            description:
+                                - "The human-readable display name for the object referred to by I(source)."
                             type: str
                             returned: Always
                         source:
-                            description: >
-                                The resource identifier.
+                            description:
+                                - "The resource identifier."
                             type: str
                             returned: Always
                         value:
-                            description: >
-                                The inherited value.
+                            description:
+                                - "The inherited value."
                             type: bool
                             returned: Always
                 ddns_use_conflict_resolution:
-                    description: >
-                        The inheritance configuration for I(ddns)useI(conflict)resolutionI( field from )IPSpace_ object.
+                    description:
+                        - "The inheritance configuration for I(ddns_use_conflict_resolution) field from I(IPSpace) object."
                     type: dict
                     returned: Always
                     contains:
                         action:
-                            description: >
-                                The inheritance setting for a field.
-                                
-                                Valid values are:
-                                * I(inherit): Use the inherited value.
-                                * I(override): Use the value set in the object.
-                                
-                                Defaults to I(inherit).
+                            description:
+                                - "The inheritance setting for a field."
+                                - "Valid values are:"
+                                - "* I(inherit): Use the inherited value."
+                                - "* I(override): Use the value set in the object."
+                                - "Defaults to I(inherit)."
                             type: str
                             returned: Always
                         display_name:
-                            description: >
-                                The human-readable display name for the object referred to by I(source).
+                            description:
+                                - "The human-readable display name for the object referred to by I(source)."
                             type: str
                             returned: Always
                         source:
-                            description: >
-                                The resource identifier.
+                            description:
+                                - "The resource identifier."
                             type: str
                             returned: Always
                         value:
-                            description: >
-                                The inherited value.
+                            description:
+                                - "The inherited value."
                             type: bool
                             returned: Always
                 dhcp_config:
-                    description: >
-                        The inheritance configuration for I(dhcp)config_ field.
+                    description:
+                        - "The inheritance configuration for I(dhcp_config) field."
                     type: dict
                     returned: Always
                     contains:
                         abandoned_reclaim_time:
-                            description: >
-                                The inheritance configuration for I(abandoned)reclaimI(time) field from I(DHCPConfig) object.
+                            description:
+                                - "The inheritance configuration for I(abandoned_reclaim_time) field from I(DHCPConfig) object."
                             type: dict
                             returned: Always
                             contains:
                                 action:
-                                    description: >
-                                        The inheritance setting for a field.
-                                        
-                                        Valid values are:
-                                        * I(inherit): Use the inherited value.
-                                        * I(override): Use the value set in the object.
-                                        
-                                        Defaults to I(inherit).
+                                    description:
+                                        - "The inheritance setting for a field."
+                                        - "Valid values are:"
+                                        - "* I(inherit): Use the inherited value."
+                                        - "* I(override): Use the value set in the object."
+                                        - "Defaults to I(inherit)."
                                     type: str
                                     returned: Always
                                 display_name:
-                                    description: >
-                                        The human-readable display name for the object referred to by I(source).
+                                    description:
+                                        - "The human-readable display name for the object referred to by I(source)."
                                     type: str
                                     returned: Always
                                 source:
-                                    description: >
-                                        The resource identifier.
+                                    description:
+                                        - "The resource identifier."
                                     type: str
                                     returned: Always
                                 value:
-                                    description: >
-                                        The inherited value.
+                                    description:
+                                        - "The inherited value."
                                     type: int
                                     returned: Always
                         abandoned_reclaim_time_v6:
-                            description: >
-                                The inheritance configuration for I(abandoned)reclaimI(time)v6I( field from )DHCPConfig_ object.
+                            description:
+                                - "The inheritance configuration for I(abandoned_reclaim_time_v6) field from I(DHCPConfig) object."
                             type: dict
                             returned: Always
                             contains:
                                 action:
-                                    description: >
-                                        The inheritance setting for a field.
-                                        
-                                        Valid values are:
-                                        * I(inherit): Use the inherited value.
-                                        * I(override): Use the value set in the object.
-                                        
-                                        Defaults to I(inherit).
+                                    description:
+                                        - "The inheritance setting for a field."
+                                        - "Valid values are:"
+                                        - "* I(inherit): Use the inherited value."
+                                        - "* I(override): Use the value set in the object."
+                                        - "Defaults to I(inherit)."
                                     type: str
                                     returned: Always
                                 display_name:
-                                    description: >
-                                        The human-readable display name for the object referred to by I(source).
+                                    description:
+                                        - "The human-readable display name for the object referred to by I(source)."
                                     type: str
                                     returned: Always
                                 source:
-                                    description: >
-                                        The resource identifier.
+                                    description:
+                                        - "The resource identifier."
                                     type: str
                                     returned: Always
                                 value:
-                                    description: >
-                                        The inherited value.
+                                    description:
+                                        - "The inherited value."
                                     type: int
                                     returned: Always
                         allow_unknown:
-                            description: >
-                                The inheritance configuration for I(allow)unknownI( field from )DHCPConfig_ object.
+                            description:
+                                - "The inheritance configuration for I(allow_unknown) field from I(DHCPConfig) object."
                             type: dict
                             returned: Always
                             contains:
                                 action:
-                                    description: >
-                                        The inheritance setting for a field.
-                                        
-                                        Valid values are:
-                                        * I(inherit): Use the inherited value.
-                                        * I(override): Use the value set in the object.
-                                        
-                                        Defaults to I(inherit).
+                                    description:
+                                        - "The inheritance setting for a field."
+                                        - "Valid values are:"
+                                        - "* I(inherit): Use the inherited value."
+                                        - "* I(override): Use the value set in the object."
+                                        - "Defaults to I(inherit)."
                                     type: str
                                     returned: Always
                                 display_name:
-                                    description: >
-                                        The human-readable display name for the object referred to by I(source).
+                                    description:
+                                        - "The human-readable display name for the object referred to by I(source)."
                                     type: str
                                     returned: Always
                                 source:
-                                    description: >
-                                        The resource identifier.
+                                    description:
+                                        - "The resource identifier."
                                     type: str
                                     returned: Always
                                 value:
-                                    description: >
-                                        The inherited value.
+                                    description:
+                                        - "The inherited value."
                                     type: bool
                                     returned: Always
                         allow_unknown_v6:
-                            description: >
-                                The inheritance configuration for I(allow)unknownI(v6) field from I(DHCPConfig) object.
+                            description:
+                                - "The inheritance configuration for I(allow_unknown_v6) field from I(DHCPConfig) object."
                             type: dict
                             returned: Always
                             contains:
                                 action:
-                                    description: >
-                                        The inheritance setting for a field.
-                                        
-                                        Valid values are:
-                                        * I(inherit): Use the inherited value.
-                                        * I(override): Use the value set in the object.
-                                        
-                                        Defaults to I(inherit).
+                                    description:
+                                        - "The inheritance setting for a field."
+                                        - "Valid values are:"
+                                        - "* I(inherit): Use the inherited value."
+                                        - "* I(override): Use the value set in the object."
+                                        - "Defaults to I(inherit)."
                                     type: str
                                     returned: Always
                                 display_name:
-                                    description: >
-                                        The human-readable display name for the object referred to by I(source).
+                                    description:
+                                        - "The human-readable display name for the object referred to by I(source)."
                                     type: str
                                     returned: Always
                                 source:
-                                    description: >
-                                        The resource identifier.
+                                    description:
+                                        - "The resource identifier."
                                     type: str
                                     returned: Always
                                 value:
-                                    description: >
-                                        The inherited value.
+                                    description:
+                                        - "The inherited value."
                                     type: bool
                                     returned: Always
                         echo_client_id:
-                            description: >
-                                The inheritance configuration for I(echo)clientI(id) field from I(DHCPConfig) object.
+                            description:
+                                - "The inheritance configuration for I(echo_client_id) field from I(DHCPConfig) object."
                             type: dict
                             returned: Always
                             contains:
                                 action:
-                                    description: >
-                                        The inheritance setting for a field.
-                                        
-                                        Valid values are:
-                                        * I(inherit): Use the inherited value.
-                                        * I(override): Use the value set in the object.
-                                        
-                                        Defaults to I(inherit).
+                                    description:
+                                        - "The inheritance setting for a field."
+                                        - "Valid values are:"
+                                        - "* I(inherit): Use the inherited value."
+                                        - "* I(override): Use the value set in the object."
+                                        - "Defaults to I(inherit)."
                                     type: str
                                     returned: Always
                                 display_name:
-                                    description: >
-                                        The human-readable display name for the object referred to by I(source).
+                                    description:
+                                        - "The human-readable display name for the object referred to by I(source)."
                                     type: str
                                     returned: Always
                                 source:
-                                    description: >
-                                        The resource identifier.
+                                    description:
+                                        - "The resource identifier."
                                     type: str
                                     returned: Always
                                 value:
-                                    description: >
-                                        The inherited value.
+                                    description:
+                                        - "The inherited value."
                                     type: bool
                                     returned: Always
                         filters:
-                            description: >
-                                The inheritance configuration for filters field from I(DHCPConfig) object.
+                            description:
+                                - "The inheritance configuration for filters field from I(DHCPConfig) object."
                             type: dict
                             returned: Always
                             contains:
                                 action:
-                                    description: >
-                                        The inheritance setting.
-                                        
-                                        Valid values are:
-                                        * I(inherit): Use the inherited value.
-                                        * I(override): Use the value set in the object.
-                                        
-                                        Defaults to I(inherit).
+                                    description:
+                                        - "The inheritance setting."
+                                        - "Valid values are:"
+                                        - "* I(inherit): Use the inherited value."
+                                        - "* I(override): Use the value set in the object."
+                                        - "Defaults to I(inherit)."
                                     type: str
                                     returned: Always
                                 display_name:
-                                    description: >
-                                        The human-readable display name for the object referred to by I(source).
+                                    description:
+                                        - "The human-readable display name for the object referred to by I(source)."
                                     type: str
                                     returned: Always
                                 source:
-                                    description: >
-                                        The resource identifier.
+                                    description:
+                                        - "The resource identifier."
                                     type: str
                                     returned: Always
                                 value:
-                                    description: >
-                                        The resource identifier.
+                                    description:
+                                        - "The resource identifier."
                                     type: list
                                     returned: Always
                         filters_v6:
-                            description: >
-                                The inheritance configuration for I(filters)v6I( field from )DHCPConfig_ object.
+                            description:
+                                - "The inheritance configuration for I(filters_v6) field from I(DHCPConfig) object."
                             type: dict
                             returned: Always
                             contains:
                                 action:
-                                    description: >
-                                        The inheritance setting.
-                                        
-                                        Valid values are:
-                                        * I(inherit): Use the inherited value.
-                                        * I(override): Use the value set in the object.
-                                        
-                                        Defaults to I(inherit).
+                                    description:
+                                        - "The inheritance setting."
+                                        - "Valid values are:"
+                                        - "* I(inherit): Use the inherited value."
+                                        - "* I(override): Use the value set in the object."
+                                        - "Defaults to I(inherit)."
                                     type: str
                                     returned: Always
                                 display_name:
-                                    description: >
-                                        The human-readable display name for the object referred to by I(source).
+                                    description:
+                                        - "The human-readable display name for the object referred to by I(source)."
                                     type: str
                                     returned: Always
                                 source:
-                                    description: >
-                                        The resource identifier.
+                                    description:
+                                        - "The resource identifier."
                                     type: str
                                     returned: Always
                                 value:
-                                    description: >
-                                        The resource identifier.
+                                    description:
+                                        - "The resource identifier."
                                     type: list
                                     returned: Always
                         ignore_client_uid:
-                            description: >
-                                The inheritance configuration for I(ignore)clientI(uid) field from I(DHCPConfig) object.
+                            description:
+                                - "The inheritance configuration for I(ignore_client_uid) field from I(DHCPConfig) object."
                             type: dict
                             returned: Always
                             contains:
                                 action:
-                                    description: >
-                                        The inheritance setting for a field.
-                                        
-                                        Valid values are:
-                                        * I(inherit): Use the inherited value.
-                                        * I(override): Use the value set in the object.
-                                        
-                                        Defaults to I(inherit).
+                                    description:
+                                        - "The inheritance setting for a field."
+                                        - "Valid values are:"
+                                        - "* I(inherit): Use the inherited value."
+                                        - "* I(override): Use the value set in the object."
+                                        - "Defaults to I(inherit)."
                                     type: str
                                     returned: Always
                                 display_name:
-                                    description: >
-                                        The human-readable display name for the object referred to by I(source).
+                                    description:
+                                        - "The human-readable display name for the object referred to by I(source)."
                                     type: str
                                     returned: Always
                                 source:
-                                    description: >
-                                        The resource identifier.
+                                    description:
+                                        - "The resource identifier."
                                     type: str
                                     returned: Always
                                 value:
-                                    description: >
-                                        The inherited value.
+                                    description:
+                                        - "The inherited value."
                                     type: bool
                                     returned: Always
                         ignore_list:
-                            description: >
-                                The inheritance configuration for I(ignore)listI( field from )DHCPConfig_ object.
+                            description:
+                                - "The inheritance configuration for I(ignore_list) field from I(DHCPConfig) object."
                             type: dict
                             returned: Always
                             contains:
                                 action:
-                                    description: >
-                                        The inheritance setting.
-                                        
-                                        Valid values are:
-                                        * I(inherit): Use the inherited value.
-                                        * I(override): Use the value set in the object.
-                                        
-                                        Defaults to I(inherit).
+                                    description:
+                                        - "The inheritance setting."
+                                        - "Valid values are:"
+                                        - "* I(inherit): Use the inherited value."
+                                        - "* I(override): Use the value set in the object."
+                                        - "Defaults to I(inherit)."
                                     type: str
                                     returned: Always
                                 display_name:
-                                    description: >
-                                        The human-readable display name for the object referred to by I(source).
+                                    description:
+                                        - "The human-readable display name for the object referred to by I(source)."
                                     type: str
                                     returned: Always
                                 source:
-                                    description: >
-                                        The resource identifier.
+                                    description:
+                                        - "The resource identifier."
                                     type: str
                                     returned: Always
                                 value:
-                                    description: >
-                                        The inherited value.
+                                    description:
+                                        - "The inherited value."
                                     type: list
                                     returned: Always
                                     elements: dict
                                     contains:
                                         type:
-                                            description: >
-                                                Type of ignore matching: client to ignore by client identifier (client hex or client text) or hardware to ignore by hardware identifier (MAC address). It can have one of the following values:
-                                                * I(client)hex_,
-                                                * I(client)text_,
-                                                * I(hardware).
+                                            description:
+                                                - "Type of ignore matching: client to ignore by client identifier (client hex or client text) or hardware to ignore by hardware identifier (MAC address). It can have one of the following values:"
+                                                - "* I(client_hex),"
+                                                - "* I(client_text),"
+                                                - "* I(hardware)."
                                             type: str
                                             returned: Always
                                         value:
-                                            description: >
-                                                Value to match.
+                                            description:
+                                                - "Value to match."
                                             type: str
                                             returned: Always
                         lease_time:
-                            description: >
-                                The inheritance configuration for I(lease)timeI( field from )DHCPConfig_ object.
+                            description:
+                                - "The inheritance configuration for I(lease_time) field from I(DHCPConfig) object."
                             type: dict
                             returned: Always
                             contains:
                                 action:
-                                    description: >
-                                        The inheritance setting for a field.
-                                        
-                                        Valid values are:
-                                        * I(inherit): Use the inherited value.
-                                        * I(override): Use the value set in the object.
-                                        
-                                        Defaults to I(inherit).
+                                    description:
+                                        - "The inheritance setting for a field."
+                                        - "Valid values are:"
+                                        - "* I(inherit): Use the inherited value."
+                                        - "* I(override): Use the value set in the object."
+                                        - "Defaults to I(inherit)."
                                     type: str
                                     returned: Always
                                 display_name:
-                                    description: >
-                                        The human-readable display name for the object referred to by I(source).
+                                    description:
+                                        - "The human-readable display name for the object referred to by I(source)."
                                     type: str
                                     returned: Always
                                 source:
-                                    description: >
-                                        The resource identifier.
+                                    description:
+                                        - "The resource identifier."
                                     type: str
                                     returned: Always
                                 value:
-                                    description: >
-                                        The inherited value.
+                                    description:
+                                        - "The inherited value."
                                     type: int
                                     returned: Always
                         lease_time_v6:
-                            description: >
-                                The inheritance configuration for I(lease)timeI(v6) field from I(DHCPConfig) object.
+                            description:
+                                - "The inheritance configuration for I(lease_time_v6) field from I(DHCPConfig) object."
                             type: dict
                             returned: Always
                             contains:
                                 action:
-                                    description: >
-                                        The inheritance setting for a field.
-                                        
-                                        Valid values are:
-                                        * I(inherit): Use the inherited value.
-                                        * I(override): Use the value set in the object.
-                                        
-                                        Defaults to I(inherit).
+                                    description:
+                                        - "The inheritance setting for a field."
+                                        - "Valid values are:"
+                                        - "* I(inherit): Use the inherited value."
+                                        - "* I(override): Use the value set in the object."
+                                        - "Defaults to I(inherit)."
                                     type: str
                                     returned: Always
                                 display_name:
-                                    description: >
-                                        The human-readable display name for the object referred to by I(source).
+                                    description:
+                                        - "The human-readable display name for the object referred to by I(source)."
                                     type: str
                                     returned: Always
                                 source:
-                                    description: >
-                                        The resource identifier.
+                                    description:
+                                        - "The resource identifier."
                                     type: str
                                     returned: Always
                                 value:
-                                    description: >
-                                        The inherited value.
+                                    description:
+                                        - "The inherited value."
                                     type: int
                                     returned: Always
                 dhcp_options:
-                    description: >
-                        The inheritance configuration for I(dhcp)options_ field.
+                    description:
+                        - "The inheritance configuration for I(dhcp_options) field."
                     type: dict
                     returned: Always
                     contains:
                         action:
-                            description: >
-                                The inheritance setting.
-                                
-                                Valid values are:
-                                * I(inherit): Use the inherited value.
-                                * I(block): Don't use the inherited value.
-                                
-                                Defaults to I(inherit).
+                            description:
+                                - "The inheritance setting."
+                                - "Valid values are:"
+                                - "* I(inherit): Use the inherited value."
+                                - "* I(block): Don&#x27;t use the inherited value."
+                                - "Defaults to I(inherit)."
                             type: str
                             returned: Always
                         value:
-                            description: >
-                                The inherited DHCP option values.
+                            description:
+                                - "The inherited DHCP option values."
                             type: list
                             returned: Always
                             elements: dict
                             contains:
                                 action:
-                                    description: >
-                                        The inheritance setting.
-                                        
-                                        Valid values are:
-                                        * I(inherit): Use the inherited value.
-                                        * I(block): Don't use the inherited value.
-                                        
-                                        Defaults to I(inherit).
+                                    description:
+                                        - "The inheritance setting."
+                                        - "Valid values are:"
+                                        - "* I(inherit): Use the inherited value."
+                                        - "* I(block): Don&#x27;t use the inherited value."
+                                        - "Defaults to I(inherit)."
                                     type: str
                                     returned: Always
                                 display_name:
-                                    description: >
-                                        The human-readable display name for the object referred to by I(source).
+                                    description:
+                                        - "The human-readable display name for the object referred to by I(source)."
                                     type: str
                                     returned: Always
                                 source:
-                                    description: >
-                                        The resource identifier.
+                                    description:
+                                        - "The resource identifier."
                                     type: str
                                     returned: Always
                                 value:
-                                    description: >
-                                        The inherited value for the DHCP option.
+                                    description:
+                                        - "The inherited value for the DHCP option."
                                     type: dict
                                     returned: Always
                                     contains:
                                         option:
-                                            description: >
-                                                Option inherited from the ancestor.
+                                            description:
+                                                - "Option inherited from the ancestor."
                                             type: dict
                                             returned: Always
                                             contains:
                                                 group:
-                                                    description: >
-                                                        The resource identifier.
+                                                    description:
+                                                        - "The resource identifier."
                                                     type: str
                                                     returned: Always
                                                 option_code:
-                                                    description: >
-                                                        The resource identifier.
+                                                    description:
+                                                        - "The resource identifier."
                                                     type: str
                                                     returned: Always
                                                 option_value:
-                                                    description: >
-                                                        The option value.
+                                                    description:
+                                                        - "The option value."
                                                     type: str
                                                     returned: Always
                                                 type:
-                                                    description: >
-                                                        The type of item.
-                                                        
-                                                        Valid values are:
-                                                        * I(group)
-                                                        * I(option)
+                                                    description:
+                                                        - "The type of item."
+                                                        - "Valid values are:"
+                                                        - "* I(group)"
+                                                        - "* I(option)"
                                                     type: str
                                                     returned: Always
                                         overriding_group:
-                                            description: >
-                                                The resource identifier.
+                                            description:
+                                                - "The resource identifier."
                                             type: str
                                             returned: Always
                 dhcp_options_v6:
-                    description: >
-                        The inheritance configuration for I(dhcp)optionsI(v6) field.
+                    description:
+                        - "The inheritance configuration for I(dhcp_options_v6) field."
                     type: dict
                     returned: Always
                     contains:
                         action:
-                            description: >
-                                The inheritance setting.
-                                
-                                Valid values are:
-                                * I(inherit): Use the inherited value.
-                                * I(block): Don't use the inherited value.
-                                
-                                Defaults to I(inherit).
+                            description:
+                                - "The inheritance setting."
+                                - "Valid values are:"
+                                - "* I(inherit): Use the inherited value."
+                                - "* I(block): Don&#x27;t use the inherited value."
+                                - "Defaults to I(inherit)."
                             type: str
                             returned: Always
                         value:
-                            description: >
-                                The inherited DHCP option values.
+                            description:
+                                - "The inherited DHCP option values."
                             type: list
                             returned: Always
                             elements: dict
                             contains:
                                 action:
-                                    description: >
-                                        The inheritance setting.
-                                        
-                                        Valid values are:
-                                        * I(inherit): Use the inherited value.
-                                        * I(block): Don't use the inherited value.
-                                        
-                                        Defaults to I(inherit).
+                                    description:
+                                        - "The inheritance setting."
+                                        - "Valid values are:"
+                                        - "* I(inherit): Use the inherited value."
+                                        - "* I(block): Don&#x27;t use the inherited value."
+                                        - "Defaults to I(inherit)."
                                     type: str
                                     returned: Always
                                 display_name:
-                                    description: >
-                                        The human-readable display name for the object referred to by I(source).
+                                    description:
+                                        - "The human-readable display name for the object referred to by I(source)."
                                     type: str
                                     returned: Always
                                 source:
-                                    description: >
-                                        The resource identifier.
+                                    description:
+                                        - "The resource identifier."
                                     type: str
                                     returned: Always
                                 value:
-                                    description: >
-                                        The inherited value for the DHCP option.
+                                    description:
+                                        - "The inherited value for the DHCP option."
                                     type: dict
                                     returned: Always
                                     contains:
                                         option:
-                                            description: >
-                                                Option inherited from the ancestor.
+                                            description:
+                                                - "Option inherited from the ancestor."
                                             type: dict
                                             returned: Always
                                             contains:
                                                 group:
-                                                    description: >
-                                                        The resource identifier.
+                                                    description:
+                                                        - "The resource identifier."
                                                     type: str
                                                     returned: Always
                                                 option_code:
-                                                    description: >
-                                                        The resource identifier.
+                                                    description:
+                                                        - "The resource identifier."
                                                     type: str
                                                     returned: Always
                                                 option_value:
-                                                    description: >
-                                                        The option value.
+                                                    description:
+                                                        - "The option value."
                                                     type: str
                                                     returned: Always
                                                 type:
-                                                    description: >
-                                                        The type of item.
-                                                        
-                                                        Valid values are:
-                                                        * I(group)
-                                                        * I(option)
+                                                    description:
+                                                        - "The type of item."
+                                                        - "Valid values are:"
+                                                        - "* I(group)"
+                                                        - "* I(option)"
                                                     type: str
                                                     returned: Always
                                         overriding_group:
-                                            description: >
-                                                The resource identifier.
+                                            description:
+                                                - "The resource identifier."
                                             type: str
                                             returned: Always
                 header_option_filename:
-                    description: >
-                        The inheritance configuration for I(header)optionI(filename) field.
+                    description:
+                        - "The inheritance configuration for I(header_option_filename) field."
                     type: dict
                     returned: Always
                     contains:
                         action:
-                            description: >
-                                The inheritance setting for a field.
-                                
-                                Valid values are:
-                                * I(inherit): Use the inherited value.
-                                * I(override): Use the value set in the object.
-                                
-                                Defaults to I(inherit).
+                            description:
+                                - "The inheritance setting for a field."
+                                - "Valid values are:"
+                                - "* I(inherit): Use the inherited value."
+                                - "* I(override): Use the value set in the object."
+                                - "Defaults to I(inherit)."
                             type: str
                             returned: Always
                         display_name:
-                            description: >
-                                The human-readable display name for the object referred to by I(source).
+                            description:
+                                - "The human-readable display name for the object referred to by I(source)."
                             type: str
                             returned: Always
                         source:
-                            description: >
-                                The resource identifier.
+                            description:
+                                - "The resource identifier."
                             type: str
                             returned: Always
                         value:
-                            description: >
-                                The inherited value.
+                            description:
+                                - "The inherited value."
                             type: str
                             returned: Always
                 header_option_server_address:
-                    description: >
-                        The inheritance configuration for I(header)optionI(server)address_ field.
+                    description:
+                        - "The inheritance configuration for I(header_option_server_address) field."
                     type: dict
                     returned: Always
                     contains:
                         action:
-                            description: >
-                                The inheritance setting for a field.
-                                
-                                Valid values are:
-                                * I(inherit): Use the inherited value.
-                                * I(override): Use the value set in the object.
-                                
-                                Defaults to I(inherit).
+                            description:
+                                - "The inheritance setting for a field."
+                                - "Valid values are:"
+                                - "* I(inherit): Use the inherited value."
+                                - "* I(override): Use the value set in the object."
+                                - "Defaults to I(inherit)."
                             type: str
                             returned: Always
                         display_name:
-                            description: >
-                                The human-readable display name for the object referred to by I(source).
+                            description:
+                                - "The human-readable display name for the object referred to by I(source)."
                             type: str
                             returned: Always
                         source:
-                            description: >
-                                The resource identifier.
+                            description:
+                                - "The resource identifier."
                             type: str
                             returned: Always
                         value:
-                            description: >
-                                The inherited value.
+                            description:
+                                - "The inherited value."
                             type: str
                             returned: Always
                 header_option_server_name:
-                    description: >
-                        The inheritance configuration for I(header)optionI(server)name_ field.
+                    description:
+                        - "The inheritance configuration for I(header_option_server_name) field."
                     type: dict
                     returned: Always
                     contains:
                         action:
-                            description: >
-                                The inheritance setting for a field.
-                                
-                                Valid values are:
-                                * I(inherit): Use the inherited value.
-                                * I(override): Use the value set in the object.
-                                
-                                Defaults to I(inherit).
+                            description:
+                                - "The inheritance setting for a field."
+                                - "Valid values are:"
+                                - "* I(inherit): Use the inherited value."
+                                - "* I(override): Use the value set in the object."
+                                - "Defaults to I(inherit)."
                             type: str
                             returned: Always
                         display_name:
-                            description: >
-                                The human-readable display name for the object referred to by I(source).
+                            description:
+                                - "The human-readable display name for the object referred to by I(source)."
                             type: str
                             returned: Always
                         source:
-                            description: >
-                                The resource identifier.
+                            description:
+                                - "The resource identifier."
                             type: str
                             returned: Always
                         value:
-                            description: >
-                                The inherited value.
+                            description:
+                                - "The inherited value."
                             type: str
                             returned: Always
                 hostname_rewrite_block:
-                    description: >
-                        The inheritance configuration for I(hostname)rewriteI(enabled), I(hostname)rewriteI(regex), and I(hostname)rewriteI(char) fields from I(IPSpace) object.
+                    description:
+                        - "The inheritance configuration for I(hostname_rewrite_enabled), I(hostname_rewrite_regex), and I(hostname_rewrite_char) fields from I(IPSpace) object."
                     type: dict
                     returned: Always
                     contains:
                         action:
-                            description: >
-                                The inheritance setting.
-                                
-                                Valid values are:
-                                * I(inherit): Use the inherited value.
-                                * I(override): Use the value set in the object.
-                                
-                                Defaults to I(inherit).
+                            description:
+                                - "The inheritance setting."
+                                - "Valid values are:"
+                                - "* I(inherit): Use the inherited value."
+                                - "* I(override): Use the value set in the object."
+                                - "Defaults to I(inherit)."
                             type: str
                             returned: Always
                         display_name:
-                            description: >
-                                The human-readable display name for the object referred to by I(source).
+                            description:
+                                - "The human-readable display name for the object referred to by I(source)."
                             type: str
                             returned: Always
                         source:
-                            description: >
-                                The resource identifier.
+                            description:
+                                - "The resource identifier."
                             type: str
                             returned: Always
                         value:
-                            description: >
-                                The inherited value.
+                            description:
+                                - "The inherited value."
                             type: dict
                             returned: Always
                             contains:
                                 hostname_rewrite_char:
-                                    description: >
-                                        The inheritance configuration for I(hostname)rewriteI(char) field.
+                                    description:
+                                        - "The inheritance configuration for I(hostname_rewrite_char) field."
                                     type: str
                                     returned: Always
                                 hostname_rewrite_enabled:
-                                    description: >
-                                        The inheritance configuration for I(hostname)rewriteI(enabled) field.
+                                    description:
+                                        - "The inheritance configuration for I(hostname_rewrite_enabled) field."
                                     type: bool
                                     returned: Always
                                 hostname_rewrite_regex:
-                                    description: >
-                                        The inheritance configuration for I(hostname)rewriteI(regex) field.
+                                    description:
+                                        - "The inheritance configuration for I(hostname_rewrite_regex) field."
                                     type: str
                                     returned: Always
                 vendor_specific_option_option_space:
-                    description: >
-                        The inheritance configuration for I(vendor)specificI(option)optionI(space) field.
+                    description:
+                        - "The inheritance configuration for I(vendor_specific_option_option_space) field."
                     type: dict
                     returned: Always
                     contains:
                         action:
-                            description: >
-                                The inheritance setting for a field.
-                                
-                                Valid values are:
-                                * I(inherit): Use the inherited value.
-                                * I(override): Use the value set in the object.
-                                
-                                Defaults to I(inherit).
+                            description:
+                                - "The inheritance setting for a field."
+                                - "Valid values are:"
+                                - "* I(inherit): Use the inherited value."
+                                - "* I(override): Use the value set in the object."
+                                - "Defaults to I(inherit)."
                             type: str
                             returned: Always
                         display_name:
-                            description: >
-                                The human-readable display name for the object referred to by I(source).
+                            description:
+                                - "The human-readable display name for the object referred to by I(source)."
                             type: str
                             returned: Always
                         source:
-                            description: >
-                                The resource identifier.
+                            description:
+                                - "The resource identifier."
                             type: str
                             returned: Always
                         value:
-                            description: >
-                                The resource identifier.
+                            description:
+                                - "The resource identifier."
                             type: str
                             returned: Always
         name:
-            description: >
-                The name of the IP space. Must contain 1 to 256 characters. Can include UTF-8.
+            description:
+                - "The name of the IP space. Must contain 1 to 256 characters. Can include UTF-8."
             type: str
             returned: Always
         tags:
-            description: >
-                The tags for the IP space in JSON format.
+            description:
+                - "The tags for the IP space in JSON format."
             type: dict
             returned: Always
         threshold:
-            description: >
-                The utilization threshold settings for the IP space.
+            description:
+                - "The utilization threshold settings for the IP space."
             type: dict
             returned: Always
             contains:
                 enabled:
-                    description: >
-                        Indicates whether the utilization threshold for IP addresses is enabled or not.
+                    description:
+                        - "Indicates whether the utilization threshold for IP addresses is enabled or not."
                     type: bool
                     returned: Always
                 high:
-                    description: >
-                        The high threshold value for the percentage of used IP addresses relative to the total IP addresses available in the scope of the object. Thresholds are inclusive in the comparison test.
+                    description:
+                        - "The high threshold value for the percentage of used IP addresses relative to the total IP addresses available in the scope of the object. Thresholds are inclusive in the comparison test."
                     type: int
                     returned: Always
                 low:
-                    description: >
-                        The low threshold value for the percentage of used IP addresses relative to the total IP addresses available in the scope of the object. Thresholds are inclusive in the comparison test.
+                    description:
+                        - "The low threshold value for the percentage of used IP addresses relative to the total IP addresses available in the scope of the object. Thresholds are inclusive in the comparison test."
                     type: int
                     returned: Always
         updated_at:
-            description: >
-                Time when the object has been updated. Equals to I(created)at_ if not updated after creation.
+            description:
+                - "Time when the object has been updated. Equals to I(created_at) if not updated after creation."
             type: str
             returned: Always
         utilization:
-            description: >
-                The utilization of IPV4 addresses in the IP space.
+            description:
+                - "The utilization of IPV4 addresses in the IP space."
             type: dict
             returned: Always
             contains:
                 abandon_utilization:
-                    description: >
-                        The percentage of abandoned IP addresses relative to the total IP addresses available in the scope of the object.
+                    description:
+                        - "The percentage of abandoned IP addresses relative to the total IP addresses available in the scope of the object."
                     type: int
                     returned: Always
                 abandoned:
-                    description: >
-                        The number of IP addresses in the scope of the object which are in the abandoned state (issued by a DHCP server and then declined by the client).
+                    description:
+                        - "The number of IP addresses in the scope of the object which are in the abandoned state (issued by a DHCP server and then declined by the client)."
                     type: str
                     returned: Always
                 dynamic:
-                    description: >
-                        The number of IP addresses handed out by DHCP in the scope of the object. This includes all leased addresses, fixed addresses that are defined but not currently leased and abandoned leases.
+                    description:
+                        - "The number of IP addresses handed out by DHCP in the scope of the object. This includes all leased addresses, fixed addresses that are defined but not currently leased and abandoned leases."
                     type: str
                     returned: Always
                 free:
-                    description: >
-                        The number of IP addresses available in the scope of the object.
+                    description:
+                        - "The number of IP addresses available in the scope of the object."
                     type: str
                     returned: Always
                 static:
-                    description: >
-                        The number of defined IP addresses such as reservations or DNS records. It can be computed as I(static) = I(used) - I(dynamic).
+                    description:
+                        - "The number of defined IP addresses such as reservations or DNS records. It can be computed as I(static) &#x3D; I(used) - I(dynamic)."
                     type: str
                     returned: Always
                 total:
-                    description: >
-                        The total number of IP addresses available in the scope of the object.
+                    description:
+                        - "The total number of IP addresses available in the scope of the object."
                     type: str
                     returned: Always
                 used:
-                    description: >
-                        The number of IP addresses used in the scope of the object.
+                    description:
+                        - "The number of IP addresses used in the scope of the object."
                     type: str
                     returned: Always
                 utilization:
-                    description: >
-                        The percentage of used IP addresses relative to the total IP addresses available in the scope of the object.
+                    description:
+                        - "The percentage of used IP addresses relative to the total IP addresses available in the scope of the object."
                     type: int
                     returned: Always
         utilization_v6:
-            description: >
-                The utilization of IPV6 addresses in the IP space.
+            description:
+                - "The utilization of IPV6 addresses in the IP space."
             type: dict
             returned: Always
             contains:
@@ -2608,8 +2420,8 @@ item:
                     type: str
                     returned: Always
         vendor_specific_option_option_space:
-            description: >
-                The resource identifier.
+            description:
+                - "The resource identifier."
             type: str
             returned: Always
 """  # noqa: E501

--- a/plugins/modules/ipam_ip_space.py
+++ b/plugins/modules/ipam_ip_space.py
@@ -10,9 +10,10 @@ __metaclass__ = type
 DOCUMENTATION = r"""
 ---
 module: ipam_ip_space
-short_description: Manage IpSpace
+short_description: Manage IP Space.
 description:
-    - Manage IpSpace
+    - Manage IP Space.
+    - The IP Space object represents an entire address space
 version_added: 2.0.0
 author: Infoblox Inc. (@infobloxopen)
 options:
@@ -88,6 +89,13 @@ options:
             - "* I(over_client_update): Same as I(server). DHCP server always updates DNS, overriding an update request from the client, unless the client requests no updates."
             - "* I(over_no_update): DHCP server updates DNS even if the client requests that no updates be done. If the client requests to do the update, DHCP server allows it."
             - "Defaults to I(client)."
+        choices:
+            - client
+            - server
+            - ignore
+            - over_client_update
+            - over_no_update
+        default: client
         type: str
     ddns_conflict_resolution_mode:
         description:
@@ -98,27 +106,37 @@ options:
             - "* I(check_exists_with_dhcid): This will check if there is an existing DHCID record but does not verify the value of the record matches the update. This will also update the DHCID record for the entry."
             - "* I(no_check_without_dhcid): This ignores conflict detection and will not add a DHCID record when creating/updating a DDNS entry."
             - "Defaults to I(check_with_dhcid)."
+        choices:
+            - check_with_dhcid
+            - no_check_with_dhcid
+            - check_exists_with_dhcid
+            - no_check_without_dhcid
+        default: check_with_dhcid
         type: str
     ddns_domain:
         description:
             - "The domain suffix for DDNS updates. FQDN, may be empty."
             - "Defaults to empty."
         type: str
+        default: ""
     ddns_generate_name:
         description:
             - "Indicates if DDNS needs to generate a hostname when not supplied by the client."
             - "Defaults to I(false)."
         type: bool
+        default: false
     ddns_generated_prefix:
         description:
             - "The prefix used in the generation of an FQDN."
             - "When generating a name, DHCP server will construct the name in the format: [ddns-generated-prefix]-[address-text].[ddns-qualifying-suffix]. where address-text is simply the lease IP address converted to a hyphenated string."
             - "Defaults to &quot;myhost&quot;."
         type: str
+        default: "myhost"
     ddns_send_updates:
         description:
             - "Determines if DDNS updates are enabled at the IP space level. Defaults to I(true)."
         type: bool
+        default: true
     ddns_ttl_percent:
         description:
             - "DDNS TTL value - to be calculated as a simple percentage of the lease&#x27;s lifetime, using the parameter&#x27;s value as the percentage. It is specified as a percentage (e.g. 25, 75). Defaults to unspecified."
@@ -128,12 +146,14 @@ options:
             - "Instructs the DHCP server to always update the DNS information when a lease is renewed even if its DNS information has not changed."
             - "Defaults to I(false)."
         type: bool
+        default: false
     ddns_use_conflict_resolution:
         description:
             - "When true, DHCP server will apply conflict resolution, as described in RFC 4703, when attempting to fulfill the update request."
             - "When false, DHCP server will simply attempt to update the DNS entries per the request, regardless of whether or not they conflict with existing entries owned by other DHCP4 clients."
             - "Defaults to I(true)."
         type: bool
+        default: true
     dhcp_config:
         description:
             - "The shared DHCP configuration for the IP space that controls how leases are issued."
@@ -181,10 +201,11 @@ options:
                 suboptions:
                     type:
                         description:
-                            - "Type of ignore matching: client to ignore by client identifier (client hex or client text) or hardware to ignore by hardware identifier (MAC address). It can have one of the following values:"
-                            - "* I(client_hex),"
-                            - "* I(client_text),"
-                            - "* I(hardware)."
+                            - "Type of ignore matching: client to ignore by client identifier (client hex or client text) or hardware to ignore by hardware identifier (MAC address)."
+                        choices:
+                            - client_hex
+                            - client_text
+                            - hardware
                         type: str
                     value:
                         description:
@@ -206,11 +227,11 @@ options:
         suboptions:
             group:
                 description:
-                    - "The resource identifier."
+                    - "The DHCP Option Group resource identifier."
                 type: str
             option_code:
                 description:
-                    - "The resource identifier."
+                    - "The DHCP option code resource identifier."
                 type: str
             option_value:
                 description:
@@ -219,9 +240,9 @@ options:
             type:
                 description:
                     - "The type of item."
-                    - "Valid values are:"
-                    - "* I(group)"
-                    - "* I(option)"
+                choices:
+                    - group
+                    - option
                 type: str
     dhcp_options_v6:
         description:
@@ -231,11 +252,11 @@ options:
         suboptions:
             group:
                 description:
-                    - "The resource identifier."
+                    - "The DHCP Option Group resource identifier."
                 type: str
             option_code:
                 description:
-                    - "The resource identifier."
+                    - "The DHCP option code resource identifier."
                 type: str
             option_value:
                 description:
@@ -244,9 +265,9 @@ options:
             type:
                 description:
                     - "The type of item."
-                    - "Valid values are:"
-                    - "* I(group)"
-                    - "* I(option)"
+                choices:
+                    - group
+                    - option
                 type: str
     header_option_filename:
         description:
@@ -266,17 +287,20 @@ options:
             - "Any single ASCII character or no character if the invalid characters should be removed without replacement."
             - "Defaults to &quot;-&quot;."
         type: str
+        default: "-"
     hostname_rewrite_enabled:
         description:
             - "Indicates if client supplied hostnames will be rewritten prior to DDNS update by replacing every character that does not match I(hostname_rewrite_regex) by I(hostname_rewrite_char)."
             - "Defaults to I(false)."
         type: bool
+        default: false
     hostname_rewrite_regex:
         description:
             - "The regex bracket expression to match valid characters."
             - "Must begin with &quot;[&quot; and end with &quot;]&quot; and be a compilable POSIX regex."
             - "Defaults to &quot;[^a-zA-Z0-9_.]&quot;."
         type: str
+        default: "[^a-zA-Z0-9_.]"
     inheritance_sources:
         description:
             - "The inheritance configuration."
@@ -295,10 +319,10 @@ options:
                             action:
                                 description:
                                     - "The inheritance setting."
-                                    - "Valid values are:"
-                                    - "* I(inherit): Use the inherited value."
-                                    - "* I(override): Use the value set in the object."
-                                    - "Defaults to I(inherit)."
+                                choices:
+                                    - inherit
+                                    - override
+                                default: inherit
                                 type: str
                     asm_growth_block:
                         description:
@@ -308,10 +332,10 @@ options:
                             action:
                                 description:
                                     - "The inheritance setting."
-                                    - "Valid values are:"
-                                    - "* I(inherit): Use the inherited value."
-                                    - "* I(override): Use the value set in the object."
-                                    - "Defaults to I(inherit)."
+                                choices:
+                                    - inherit
+                                    - override
+                                default: inherit
                                 type: str
                     asm_threshold:
                         description:
@@ -321,10 +345,10 @@ options:
                             action:
                                 description:
                                     - "The inheritance setting for a field."
-                                    - "Valid values are:"
-                                    - "* I(inherit): Use the inherited value."
-                                    - "* I(override): Use the value set in the object."
-                                    - "Defaults to I(inherit)."
+                                choices:
+                                    - inherit
+                                    - override
+                                default: inherit
                                 type: str
                     forecast_period:
                         description:
@@ -334,10 +358,10 @@ options:
                             action:
                                 description:
                                     - "The inheritance setting for a field."
-                                    - "Valid values are:"
-                                    - "* I(inherit): Use the inherited value."
-                                    - "* I(override): Use the value set in the object."
-                                    - "Defaults to I(inherit)."
+                                choices:
+                                    - inherit
+                                    - override
+                                default: inherit
                                 type: str
                     history:
                         description:
@@ -347,10 +371,10 @@ options:
                             action:
                                 description:
                                     - "The inheritance setting for a field."
-                                    - "Valid values are:"
-                                    - "* I(inherit): Use the inherited value."
-                                    - "* I(override): Use the value set in the object."
-                                    - "Defaults to I(inherit)."
+                                choices:
+                                    - inherit
+                                    - override
+                                default: inherit
                                 type: str
                     min_total:
                         description:
@@ -360,10 +384,10 @@ options:
                             action:
                                 description:
                                     - "The inheritance setting for a field."
-                                    - "Valid values are:"
-                                    - "* I(inherit): Use the inherited value."
-                                    - "* I(override): Use the value set in the object."
-                                    - "Defaults to I(inherit)."
+                                choices:
+                                    - inherit
+                                    - override
+                                default: inherit
                                 type: str
                     min_unused:
                         description:
@@ -373,10 +397,10 @@ options:
                             action:
                                 description:
                                     - "The inheritance setting for a field."
-                                    - "Valid values are:"
-                                    - "* I(inherit): Use the inherited value."
-                                    - "* I(override): Use the value set in the object."
-                                    - "Defaults to I(inherit)."
+                                choices:
+                                    - inherit
+                                    - override
+                                default: inherit
                                 type: str
             ddns_client_update:
                 description:
@@ -386,10 +410,10 @@ options:
                     action:
                         description:
                             - "The inheritance setting for a field."
-                            - "Valid values are:"
-                            - "* I(inherit): Use the inherited value."
-                            - "* I(override): Use the value set in the object."
-                            - "Defaults to I(inherit)."
+                        choices:
+                            - inherit
+                            - override
+                        default: inherit
                         type: str
             ddns_conflict_resolution_mode:
                 description:
@@ -399,10 +423,10 @@ options:
                     action:
                         description:
                             - "The inheritance setting for a field."
-                            - "Valid values are:"
-                            - "* I(inherit): Use the inherited value."
-                            - "* I(override): Use the value set in the object."
-                            - "Defaults to I(inherit)."
+                        choices:
+                            - inherit
+                            - override
+                        default: inherit
                         type: str
             ddns_enabled:
                 description:
@@ -412,10 +436,10 @@ options:
                     action:
                         description:
                             - "The inheritance setting for a field."
-                            - "Valid values are:"
-                            - "* I(inherit): Use the inherited value."
-                            - "* I(override): Use the value set in the object."
-                            - "Defaults to I(inherit)."
+                        choices:
+                            - inherit
+                            - override
+                        default: inherit
                         type: str
             ddns_hostname_block:
                 description:
@@ -425,10 +449,10 @@ options:
                     action:
                         description:
                             - "The inheritance setting."
-                            - "Valid values are:"
-                            - "* I(inherit): Use the inherited value."
-                            - "* I(override): Use the value set in the object."
-                            - "Defaults to I(inherit)."
+                        choices:
+                            - inherit
+                            - override
+                        default: inherit
                         type: str
             ddns_ttl_percent:
                 description:
@@ -438,10 +462,10 @@ options:
                     action:
                         description:
                             - "The inheritance setting for a field."
-                            - "Valid values are:"
-                            - "* I(inherit): Use the inherited value."
-                            - "* I(override): Use the value set in the object."
-                            - "Defaults to I(inherit)."
+                        choices:
+                            - inherit
+                            - override
+                        default: inherit
                         type: str
             ddns_update_block:
                 description:
@@ -451,10 +475,10 @@ options:
                     action:
                         description:
                             - "The inheritance setting."
-                            - "Valid values are:"
-                            - "* I(inherit): Use the inherited value."
-                            - "* I(override): Use the value set in the object."
-                            - "Defaults to I(inherit)."
+                        choices:
+                            - inherit
+                            - override
+                        default: inherit
                         type: str
             ddns_update_on_renew:
                 description:
@@ -464,10 +488,10 @@ options:
                     action:
                         description:
                             - "The inheritance setting for a field."
-                            - "Valid values are:"
-                            - "* I(inherit): Use the inherited value."
-                            - "* I(override): Use the value set in the object."
-                            - "Defaults to I(inherit)."
+                        choices:
+                            - inherit
+                            - override
+                        default: inherit
                         type: str
             ddns_use_conflict_resolution:
                 description:
@@ -477,10 +501,10 @@ options:
                     action:
                         description:
                             - "The inheritance setting for a field."
-                            - "Valid values are:"
-                            - "* I(inherit): Use the inherited value."
-                            - "* I(override): Use the value set in the object."
-                            - "Defaults to I(inherit)."
+                        choices:
+                            - inherit
+                            - override
+                        default: inherit
                         type: str
             dhcp_config:
                 description:
@@ -495,10 +519,10 @@ options:
                             action:
                                 description:
                                     - "The inheritance setting for a field."
-                                    - "Valid values are:"
-                                    - "* I(inherit): Use the inherited value."
-                                    - "* I(override): Use the value set in the object."
-                                    - "Defaults to I(inherit)."
+                                choices:
+                                    - inherit
+                                    - override
+                                default: inherit
                                 type: str
                     abandoned_reclaim_time_v6:
                         description:
@@ -508,10 +532,10 @@ options:
                             action:
                                 description:
                                     - "The inheritance setting for a field."
-                                    - "Valid values are:"
-                                    - "* I(inherit): Use the inherited value."
-                                    - "* I(override): Use the value set in the object."
-                                    - "Defaults to I(inherit)."
+                                choices:
+                                    - inherit
+                                    - override
+                                default: inherit
                                 type: str
                     allow_unknown:
                         description:
@@ -521,10 +545,10 @@ options:
                             action:
                                 description:
                                     - "The inheritance setting for a field."
-                                    - "Valid values are:"
-                                    - "* I(inherit): Use the inherited value."
-                                    - "* I(override): Use the value set in the object."
-                                    - "Defaults to I(inherit)."
+                                choices:
+                                    - inherit
+                                    - override
+                                default: inherit
                                 type: str
                     allow_unknown_v6:
                         description:
@@ -534,10 +558,10 @@ options:
                             action:
                                 description:
                                     - "The inheritance setting for a field."
-                                    - "Valid values are:"
-                                    - "* I(inherit): Use the inherited value."
-                                    - "* I(override): Use the value set in the object."
-                                    - "Defaults to I(inherit)."
+                                choices:
+                                    - inherit
+                                    - override
+                                default: inherit
                                 type: str
                     echo_client_id:
                         description:
@@ -547,10 +571,10 @@ options:
                             action:
                                 description:
                                     - "The inheritance setting for a field."
-                                    - "Valid values are:"
-                                    - "* I(inherit): Use the inherited value."
-                                    - "* I(override): Use the value set in the object."
-                                    - "Defaults to I(inherit)."
+                                choices:
+                                    - inherit
+                                    - override
+                                default: inherit
                                 type: str
                     filters:
                         description:
@@ -560,16 +584,11 @@ options:
                             action:
                                 description:
                                     - "The inheritance setting."
-                                    - "Valid values are:"
-                                    - "* I(inherit): Use the inherited value."
-                                    - "* I(override): Use the value set in the object."
-                                    - "Defaults to I(inherit)."
+                                choices:
+                                    - inherit
+                                    - override
+                                default: inherit
                                 type: str
-                            value:
-                                description:
-                                    - "The resource identifier."
-                                type: list
-                                elements: str
                     filters_v6:
                         description:
                             - "The inheritance configuration for I(filters_v6) field from I(DHCPConfig) object."
@@ -578,16 +597,11 @@ options:
                             action:
                                 description:
                                     - "The inheritance setting."
-                                    - "Valid values are:"
-                                    - "* I(inherit): Use the inherited value."
-                                    - "* I(override): Use the value set in the object."
-                                    - "Defaults to I(inherit)."
+                                choices:
+                                    - inherit
+                                    - override
+                                default: inherit
                                 type: str
-                            value:
-                                description:
-                                    - "The resource identifier."
-                                type: list
-                                elements: str
                     ignore_client_uid:
                         description:
                             - "The inheritance configuration for I(ignore_client_uid) field from I(DHCPConfig) object."
@@ -596,10 +610,10 @@ options:
                             action:
                                 description:
                                     - "The inheritance setting for a field."
-                                    - "Valid values are:"
-                                    - "* I(inherit): Use the inherited value."
-                                    - "* I(override): Use the value set in the object."
-                                    - "Defaults to I(inherit)."
+                                choices:
+                                    - inherit
+                                    - override
+                                default: inherit
                                 type: str
                     ignore_list:
                         description:
@@ -609,10 +623,10 @@ options:
                             action:
                                 description:
                                     - "The inheritance setting."
-                                    - "Valid values are:"
-                                    - "* I(inherit): Use the inherited value."
-                                    - "* I(override): Use the value set in the object."
-                                    - "Defaults to I(inherit)."
+                                choices:
+                                    - inherit
+                                    - override
+                                default: inherit
                                 type: str
                     lease_time:
                         description:
@@ -622,10 +636,10 @@ options:
                             action:
                                 description:
                                     - "The inheritance setting for a field."
-                                    - "Valid values are:"
-                                    - "* I(inherit): Use the inherited value."
-                                    - "* I(override): Use the value set in the object."
-                                    - "Defaults to I(inherit)."
+                                choices:
+                                    - inherit
+                                    - override
+                                default: inherit
                                 type: str
                     lease_time_v6:
                         description:
@@ -635,10 +649,10 @@ options:
                             action:
                                 description:
                                     - "The inheritance setting for a field."
-                                    - "Valid values are:"
-                                    - "* I(inherit): Use the inherited value."
-                                    - "* I(override): Use the value set in the object."
-                                    - "Defaults to I(inherit)."
+                                choices:
+                                    - inherit
+                                    - override
+                                default: inherit
                                 type: str
             dhcp_options:
                 description:
@@ -652,6 +666,10 @@ options:
                             - "* I(inherit): Use the inherited value."
                             - "* I(block): Don&#x27;t use the inherited value."
                             - "Defaults to I(inherit)."
+                        choices:
+                            - inherit
+                            - block
+                        default: inherit
                         type: str
                     value:
                         description:
@@ -665,7 +683,10 @@ options:
                                     - "Valid values are:"
                                     - "* I(inherit): Use the inherited value."
                                     - "* I(block): Don&#x27;t use the inherited value."
-                                    - "Defaults to I(inherit)."
+                                choices:
+                                    - inherit
+                                    - block
+                                default: inherit
                                 type: str
             dhcp_options_v6:
                 description:
@@ -678,7 +699,10 @@ options:
                             - "Valid values are:"
                             - "* I(inherit): Use the inherited value."
                             - "* I(block): Don&#x27;t use the inherited value."
-                            - "Defaults to I(inherit)."
+                        choices:
+                            - inherit
+                            - block
+                        default: inherit
                         type: str
                     value:
                         description:
@@ -692,7 +716,10 @@ options:
                                     - "Valid values are:"
                                     - "* I(inherit): Use the inherited value."
                                     - "* I(block): Don&#x27;t use the inherited value."
-                                    - "Defaults to I(inherit)."
+                                choices:
+                                    - inherit
+                                    - block
+                                default: inherit
                                 type: str
             header_option_filename:
                 description:
@@ -702,10 +729,10 @@ options:
                     action:
                         description:
                             - "The inheritance setting for a field."
-                            - "Valid values are:"
-                            - "* I(inherit): Use the inherited value."
-                            - "* I(override): Use the value set in the object."
-                            - "Defaults to I(inherit)."
+                        choices:
+                            - inherit
+                            - override
+                        default: inherit
                         type: str
             header_option_server_address:
                 description:
@@ -715,10 +742,10 @@ options:
                     action:
                         description:
                             - "The inheritance setting for a field."
-                            - "Valid values are:"
-                            - "* I(inherit): Use the inherited value."
-                            - "* I(override): Use the value set in the object."
-                            - "Defaults to I(inherit)."
+                        choices:
+                            - inherit
+                            - override
+                        default: inherit
                         type: str
             header_option_server_name:
                 description:
@@ -728,10 +755,10 @@ options:
                     action:
                         description:
                             - "The inheritance setting for a field."
-                            - "Valid values are:"
-                            - "* I(inherit): Use the inherited value."
-                            - "* I(override): Use the value set in the object."
-                            - "Defaults to I(inherit)."
+                        choices:
+                            - inherit
+                            - override
+                        default: inherit
                         type: str
             hostname_rewrite_block:
                 description:
@@ -741,10 +768,10 @@ options:
                     action:
                         description:
                             - "The inheritance setting."
-                            - "Valid values are:"
-                            - "* I(inherit): Use the inherited value."
-                            - "* I(override): Use the value set in the object."
-                            - "Defaults to I(inherit)."
+                        choices:
+                            - inherit
+                            - override
+                        default: inherit
                         type: str
             vendor_specific_option_option_space:
                 description:
@@ -754,14 +781,10 @@ options:
                     action:
                         description:
                             - "The inheritance setting for a field."
-                            - "Valid values are:"
-                            - "* I(inherit): Use the inherited value."
-                            - "* I(override): Use the value set in the object."
-                            - "Defaults to I(inherit)."
-                        type: str
-                    value:
-                        description:
-                            - "The resource identifier."
+                        choices:
+                            - inherit
+                            - override
+                        default: inherit
                         type: str
     name:
         description:
@@ -773,7 +796,7 @@ options:
         type: dict
     vendor_specific_option_option_space:
         description:
-            - "The resource identifier."
+            - "The DHCP Option Space resource identifier."
         type: str
 
 extends_documentation_fragment:
@@ -792,6 +815,39 @@ EXAMPLES = r"""
       tags:
         location: "my-location"
 
+  - name: "Create an IP space with DHCP configuration value overridden"
+    infoblox.bloxone.ipam_ip_space:
+        name: "my-ip-space"
+        dhcp_config:
+            abandoned_reclaim_time: 3600
+        inheritance_sources:
+            dhcp_config:
+                lease_time:
+                    action: override
+
+                # The API currently requires all fields inside the inheritance config to be explicitly provided,
+                # or it fails with error 'The value of an inheritance action field is not valid'.
+                abandoned_reclaim_time:
+                    action: inherit
+                abandoned_reclaim_time_v6:
+                    action: inherit
+                allow_unknown:
+                      action: inherit
+                allow_unknown_v6:
+                    action: inherit
+                echo_client_id:
+                    action: inherit
+                filters:
+                    action: inherit
+                filters_v6:
+                    action: inherit
+                ignore_client_uid:
+                    action: inherit
+                ignore_list:
+                    action: inherit
+                lease_time_v6:
+                    action: inherit
+
   - name: "Delete an IP space"
     infoblox.bloxone.ipam_ip_space:
       name: "my-ip-space"
@@ -801,12 +857,12 @@ EXAMPLES = r"""
 RETURN = r"""
 id:
     description:
-        - ID of the IpSpace object
+        - ID of the IP Space object
     type: str
     returned: Always
 item:
     description:
-        - IpSpace object
+        - IP Space object
     type: complex
     returned: Always
     contains:
@@ -2435,9 +2491,9 @@ except ImportError:
     pass  # Handled by BloxoneAnsibleModule
 
 
-class IpSpaceModule(BloxoneAnsibleModule):
+class IPSpaceModule(BloxoneAnsibleModule):
     def __init__(self, *args, **kwargs):
-        super(IpSpaceModule, self).__init__(*args, **kwargs)
+        super(IPSpaceModule, self).__init__(*args, **kwargs)
 
         exclude = ["state", "csp_url", "api_key", "id"]
         self._payload_params = {k: v for k, v in self.params.items() if v is not None and k not in exclude}
@@ -2566,15 +2622,21 @@ def main():
             ),
         ),
         comment=dict(type="str"),
-        ddns_client_update=dict(type="str"),
-        ddns_conflict_resolution_mode=dict(type="str"),
-        ddns_domain=dict(type="str"),
-        ddns_generate_name=dict(type="bool"),
-        ddns_generated_prefix=dict(type="str"),
-        ddns_send_updates=dict(type="bool"),
+        ddns_client_update=dict(
+            type="str", choices=["client", "server", "ignore", "over_client_update", "over_no_update"], default="client"
+        ),
+        ddns_conflict_resolution_mode=dict(
+            type="str",
+            choices=["check_with_dhcid", "no_check_with_dhcid", "check_exists_with_dhcid", "no_check_without_dhcid"],
+            default="check_with_dhcid",
+        ),
+        ddns_domain=dict(type="str", default=""),
+        ddns_generate_name=dict(type="bool", default=False),
+        ddns_generated_prefix=dict(type="str", default="myhost"),
+        ddns_send_updates=dict(type="bool", default=True),
         ddns_ttl_percent=dict(type="float"),
-        ddns_update_on_renew=dict(type="bool"),
-        ddns_use_conflict_resolution=dict(type="bool"),
+        ddns_update_on_renew=dict(type="bool", default=False),
+        ddns_use_conflict_resolution=dict(type="bool", default=True),
         dhcp_config=dict(
             type="dict",
             options=dict(
@@ -2590,7 +2652,7 @@ def main():
                     type="list",
                     elements="dict",
                     options=dict(
-                        type=dict(type="str"),
+                        type=dict(type="str", choices=["client_hex", "client_text", "hardware"]),
                         value=dict(type="str"),
                     ),
                 ),
@@ -2605,7 +2667,7 @@ def main():
                 group=dict(type="str"),
                 option_code=dict(type="str"),
                 option_value=dict(type="str"),
-                type=dict(type="str"),
+                type=dict(type="str", choices=["group", "option"]),
             ),
         ),
         dhcp_options_v6=dict(
@@ -2615,15 +2677,15 @@ def main():
                 group=dict(type="str"),
                 option_code=dict(type="str"),
                 option_value=dict(type="str"),
-                type=dict(type="str"),
+                type=dict(type="str", choices=["group", "option"]),
             ),
         ),
         header_option_filename=dict(type="str"),
         header_option_server_address=dict(type="str"),
         header_option_server_name=dict(type="str"),
-        hostname_rewrite_char=dict(type="str"),
-        hostname_rewrite_enabled=dict(type="bool"),
-        hostname_rewrite_regex=dict(type="str"),
+        hostname_rewrite_char=dict(type="str", default="-"),
+        hostname_rewrite_enabled=dict(type="bool", default=False),
+        hostname_rewrite_regex=dict(type="str", default="[^a-zA-Z0-9_.]"),
         inheritance_sources=dict(
             type="dict",
             options=dict(
@@ -2633,43 +2695,43 @@ def main():
                         asm_enable_block=dict(
                             type="dict",
                             options=dict(
-                                action=dict(type="str"),
+                                action=dict(type="str", choices=["inherit", "override"], default="inherit"),
                             ),
                         ),
                         asm_growth_block=dict(
                             type="dict",
                             options=dict(
-                                action=dict(type="str"),
+                                action=dict(type="str", choices=["inherit", "override"], default="inherit"),
                             ),
                         ),
                         asm_threshold=dict(
                             type="dict",
                             options=dict(
-                                action=dict(type="str"),
+                                action=dict(type="str", choices=["inherit", "override"], default="inherit"),
                             ),
                         ),
                         forecast_period=dict(
                             type="dict",
                             options=dict(
-                                action=dict(type="str"),
+                                action=dict(type="str", choices=["inherit", "override"], default="inherit"),
                             ),
                         ),
                         history=dict(
                             type="dict",
                             options=dict(
-                                action=dict(type="str"),
+                                action=dict(type="str", choices=["inherit", "override"], default="inherit"),
                             ),
                         ),
                         min_total=dict(
                             type="dict",
                             options=dict(
-                                action=dict(type="str"),
+                                action=dict(type="str", choices=["inherit", "override"], default="inherit"),
                             ),
                         ),
                         min_unused=dict(
                             type="dict",
                             options=dict(
-                                action=dict(type="str"),
+                                action=dict(type="str", choices=["inherit", "override"], default="inherit"),
                             ),
                         ),
                     ),
@@ -2677,49 +2739,49 @@ def main():
                 ddns_client_update=dict(
                     type="dict",
                     options=dict(
-                        action=dict(type="str"),
+                        action=dict(type="str", choices=["inherit", "override"], default="inherit"),
                     ),
                 ),
                 ddns_conflict_resolution_mode=dict(
                     type="dict",
                     options=dict(
-                        action=dict(type="str"),
+                        action=dict(type="str", choices=["inherit", "override"], default="inherit"),
                     ),
                 ),
                 ddns_enabled=dict(
                     type="dict",
                     options=dict(
-                        action=dict(type="str"),
+                        action=dict(type="str", choices=["inherit", "override"], default="inherit"),
                     ),
                 ),
                 ddns_hostname_block=dict(
                     type="dict",
                     options=dict(
-                        action=dict(type="str"),
+                        action=dict(type="str", choices=["inherit", "override"], default="inherit"),
                     ),
                 ),
                 ddns_ttl_percent=dict(
                     type="dict",
                     options=dict(
-                        action=dict(type="str"),
+                        action=dict(type="str", choices=["inherit", "override"], default="inherit"),
                     ),
                 ),
                 ddns_update_block=dict(
                     type="dict",
                     options=dict(
-                        action=dict(type="str"),
+                        action=dict(type="str", choices=["inherit", "override"], default="inherit"),
                     ),
                 ),
                 ddns_update_on_renew=dict(
                     type="dict",
                     options=dict(
-                        action=dict(type="str"),
+                        action=dict(type="str", choices=["inherit", "override"], default="inherit"),
                     ),
                 ),
                 ddns_use_conflict_resolution=dict(
                     type="dict",
                     options=dict(
-                        action=dict(type="str"),
+                        action=dict(type="str", choices=["inherit", "override"], default="inherit"),
                     ),
                 ),
                 dhcp_config=dict(
@@ -2728,69 +2790,67 @@ def main():
                         abandoned_reclaim_time=dict(
                             type="dict",
                             options=dict(
-                                action=dict(type="str"),
+                                action=dict(type="str", choices=["inherit", "override"], default="inherit"),
                             ),
                         ),
                         abandoned_reclaim_time_v6=dict(
                             type="dict",
                             options=dict(
-                                action=dict(type="str"),
+                                action=dict(type="str", choices=["inherit", "override"], default="inherit"),
                             ),
                         ),
                         allow_unknown=dict(
                             type="dict",
                             options=dict(
-                                action=dict(type="str"),
+                                action=dict(type="str", choices=["inherit", "override"], default="inherit"),
                             ),
                         ),
                         allow_unknown_v6=dict(
                             type="dict",
                             options=dict(
-                                action=dict(type="str"),
+                                action=dict(type="str", choices=["inherit", "override"], default="inherit"),
                             ),
                         ),
                         echo_client_id=dict(
                             type="dict",
                             options=dict(
-                                action=dict(type="str"),
+                                action=dict(type="str", choices=["inherit", "override"], default="inherit"),
                             ),
                         ),
                         filters=dict(
                             type="dict",
                             options=dict(
-                                action=dict(type="str"),
-                                value=dict(type="list", elements="str"),
+                                action=dict(type="str", choices=["inherit", "override"], default="inherit"),
                             ),
                         ),
                         filters_v6=dict(
                             type="dict",
                             options=dict(
-                                action=dict(type="str"),
-                                value=dict(type="list", elements="str"),
+                                action=dict(type="str", choices=["inherit", "override"], default="inherit"),
                             ),
                         ),
                         ignore_client_uid=dict(
                             type="dict",
                             options=dict(
-                                action=dict(type="str"),
+                                action=dict(type="str", choices=["inherit", "override"], default="inherit"),
                             ),
                         ),
                         ignore_list=dict(
                             type="dict",
                             options=dict(
-                                action=dict(type="str"),
+                                action=dict(type="str", choices=["inherit", "override"], default="inherit"),
                             ),
                         ),
                         lease_time=dict(
                             type="dict",
                             options=dict(
-                                action=dict(type="str"),
+                                action=dict(type="str", choices=["inherit", "override"], default="inherit"),
                             ),
                         ),
                         lease_time_v6=dict(
                             type="dict",
                             options=dict(
-                                action=dict(type="str"),
+                                action=dict(type="str", choices=["inherit", "override"], default="inherit"),
                             ),
                         ),
                     ),
@@ -2798,12 +2858,12 @@ def main():
                 dhcp_options=dict(
                     type="dict",
                     options=dict(
-                        action=dict(type="str"),
+                        action=dict(type="str", choices=["inherit", "block"], default="inherit"),
                         value=dict(
                             type="list",
                             elements="dict",
                             options=dict(
-                                action=dict(type="str"),
+                                action=dict(type="str", choices=["inherit", "block"], default="inherit"),
                             ),
                         ),
                     ),
@@ -2811,12 +2871,12 @@ def main():
                 dhcp_options_v6=dict(
                     type="dict",
                     options=dict(
-                        action=dict(type="str"),
+                        action=dict(type="str", choices=["inherit", "block"], default="inherit"),
                         value=dict(
                             type="list",
                             elements="dict",
                             options=dict(
-                                action=dict(type="str"),
+                                action=dict(type="str", choices=["inherit", "block"], default="inherit"),
                             ),
                         ),
                     ),
@@ -2824,32 +2884,31 @@ def main():
                 header_option_filename=dict(
                     type="dict",
                     options=dict(
-                        action=dict(type="str"),
+                        action=dict(type="str", choices=["inherit", "override"], default="inherit"),
                     ),
                 ),
                 header_option_server_address=dict(
                     type="dict",
                     options=dict(
-                        action=dict(type="str"),
+                        action=dict(type="str", choices=["inherit", "override"], default="inherit"),
                     ),
                 ),
                 header_option_server_name=dict(
                     type="dict",
                     options=dict(
-                        action=dict(type="str"),
+                        action=dict(type="str", choices=["inherit", "override"], default="inherit"),
                     ),
                 ),
                 hostname_rewrite_block=dict(
                     type="dict",
                     options=dict(
-                        action=dict(type="str"),
+                        action=dict(type="str", choices=["inherit", "override"], default="inherit"),
                     ),
                 ),
                 vendor_specific_option_option_space=dict(
                     type="dict",
                     options=dict(
-                        action=dict(type="str"),
-                        value=dict(type="str"),
+                        action=dict(type="str", choices=["inherit", "override"], default="inherit"),
                     ),
                 ),
             ),
@@ -2859,7 +2918,7 @@ def main():
         vendor_specific_option_option_space=dict(type="str"),
     )
 
-    module = IpSpaceModule(
+    module = IPSpaceModule(
         argument_spec=module_args,
         supports_check_mode=True,
         required_if=[("state", "present", ["name"])],

--- a/plugins/modules/ipam_ip_space.py
+++ b/plugins/modules/ipam_ip_space.py
@@ -2695,7 +2695,7 @@ class IpSpaceModule(BloxoneAnsibleModule):
         IpSpaceApi(self.client).delete(self.existing.id)
 
     def run_command(self):
-        result = dict(changed=False, item={}, id=None)
+        result = dict(changed=False, object={}, id=None)
 
         # based on the state that is passed in, we will execute the appropriate
         # functions
@@ -2724,7 +2724,7 @@ class IpSpaceModule(BloxoneAnsibleModule):
                 before=self.existing.model_dump(by_alias=True, exclude_none=True) if self.existing is not None else {},
                 after=item,
             )
-            result["item"] = item
+            result["object"] = item
             result["id"] = (
                 self.existing.id if self.existing is not None else item["id"] if (item and "id" in item) else None
             )
@@ -2735,7 +2735,9 @@ class IpSpaceModule(BloxoneAnsibleModule):
 
 
 def main():
-    object_args = dict(
+    module_args = dict(
+        id=dict(type="str", required=False),
+        state=dict(type="str", required=False, choices=["present", "absent"], default="present"),
         asm_config=dict(
             type="dict",
             options=dict(
@@ -3044,12 +3046,6 @@ def main():
         tags=dict(type="dict"),
         vendor_specific_option_option_space=dict(type="str"),
     )
-
-    module_args = dict(
-        id=dict(type="str", required=False),
-        state=dict(type="str", required=False, choices=["present", "absent"], default="present"),
-    )
-    module_args.update(object_args)
 
     module = IpSpaceModule(
         argument_spec=module_args,

--- a/plugins/modules/ipam_ip_space.py
+++ b/plugins/modules/ipam_ip_space.py
@@ -1,0 +1,3064 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: Infoblox Inc.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ipam_ip_space
+short_description: Manage IpSpace
+description:
+    - Manage IpSpace
+version_added: 2.0.0
+author: Infoblox Inc. (@infobloxopen)
+options:
+    id:
+        description:
+            - ID of the object
+        type: str
+        required: false
+    state:
+        description:
+            - Indicate desired state of the object
+        type: str
+        required: false
+        choices:
+            - present
+            - absent
+        default: present
+    asm_config:
+        description: >
+            The Automated Scope Management configuration for the IP space.
+        type: dict
+        suboptions:
+            asm_threshold:
+                description: >
+                    ASM shows the number of addresses forecast to be used I(forecast)periodI( days in the future, if it is greater than )asmI(threshold) percent * I(dhcp)totalI( (see )dhcpI(utilization)) then the subnet is flagged.
+                type: int
+            enable:
+                description: >
+                    Indicates if Automated Scope Management is enabled.
+                type: bool
+            enable_notification:
+                description: >
+                    Indicates if ASM should send notifications to the user.
+                type: bool
+            forecast_period:
+                description: >
+                    The forecast period in days.
+                type: int
+            growth_factor:
+                description: >
+                    Indicates the growth in the number or percentage of IP addresses.
+                type: int
+            growth_type:
+                description: >
+                    The type of factor to use: I(percent) or I(count).
+                type: str
+            history:
+                description: >
+                    The minimum amount of history needed before ASM can run on this subnet.
+                type: int
+            min_total:
+                description: >
+                    The minimum size of range needed for ASM to run on this subnet.
+                type: int
+            min_unused:
+                description: >
+                    The minimum percentage of addresses that must be available outside of the DHCP ranges and fixed addresses
+                    when making a suggested change..
+                type: int
+            reenable_date:
+                description: ""
+                type: str
+    comment:
+        description: >
+            The description for the IP space. May contain 0 to 1024 characters. Can include UTF-8.
+        type: str
+    ddns_client_update:
+        description: >
+            Controls who does the DDNS updates.
+            
+            Valid values are:
+            * I(client): DHCP server updates DNS if requested by client.
+            * I(server): DHCP server always updates DNS, overriding an update request from the client, unless the client requests no updates.
+            * I(ignore): DHCP server always updates DNS, even if the client says not to.
+            * I(over)clientI(update): Same as I(server). DHCP server always updates DNS, overriding an update request from the client, unless the client requests no updates.
+            * I(over)noI(update): DHCP server updates DNS even if the client requests that no updates be done. If the client requests to do the update, DHCP server allows it.
+            
+            Defaults to I(client).
+        type: str
+    ddns_conflict_resolution_mode:
+        description: >
+            The mode used for resolving conflicts while performing DDNS updates.
+            
+            Valid values are:
+            * I(check)withI(dhcid): It includes adding a DHCID record and checking that record via conflict detection as per RFC 4703.
+            * I(no)checkI(with)dhcid_: This will ignore conflict detection but add a DHCID record when creating/updating an entry.
+            * I(check)existsI(with)dhcid_: This will check if there is an existing DHCID record but does not verify the value of the record matches the update. This will also update the DHCID record for the entry.
+            * I(no)checkI(without)dhcid_: This ignores conflict detection and will not add a DHCID record when creating/updating a DDNS entry.
+            
+            Defaults to I(check)withI(dhcid).
+        type: str
+    ddns_domain:
+        description: >
+            The domain suffix for DDNS updates. FQDN, may be empty.
+            
+            Defaults to empty.
+        type: str
+    ddns_generate_name:
+        description: >
+            Indicates if DDNS needs to generate a hostname when not supplied by the client.
+            
+            Defaults to I(false).
+        type: bool
+    ddns_generated_prefix:
+        description: >
+            The prefix used in the generation of an FQDN.
+            
+            When generating a name, DHCP server will construct the name in the format: [ddns-generated-prefix]-[address-text].[ddns-qualifying-suffix].
+            where address-text is simply the lease IP address converted to a hyphenated string.
+            
+            Defaults to "myhost".
+        type: str
+    ddns_send_updates:
+        description: >
+            Determines if DDNS updates are enabled at the IP space level.
+            Defaults to I(true).
+        type: bool
+    ddns_ttl_percent:
+        description: >
+            DDNS TTL value - to be calculated as a simple percentage of the lease's lifetime, using the parameter's value as the percentage.
+            It is specified as a percentage (e.g. 25, 75).
+            Defaults to unspecified.
+        type: float
+    ddns_update_on_renew:
+        description: >
+            Instructs the DHCP server to always update the DNS information when a lease is renewed even if its DNS information has not changed.
+            
+            Defaults to I(false).
+        type: bool
+    ddns_use_conflict_resolution:
+        description: >
+            When true, DHCP server will apply conflict resolution, as described in RFC 4703, when attempting to fulfill the update request.
+            
+            When false, DHCP server will simply attempt to update the DNS entries per the request, regardless of whether or not they conflict with existing entries owned by other DHCP4 clients.
+            
+            Defaults to I(true).
+        type: bool
+    dhcp_config:
+        description: >
+            The shared DHCP configuration for the IP space that controls how leases are issued.
+        type: dict
+        suboptions:
+            abandoned_reclaim_time:
+                description: >
+                    The abandoned reclaim time in seconds for IPV4 clients.
+                type: int
+            abandoned_reclaim_time_v6:
+                description: >
+                    The abandoned reclaim time in seconds for IPV6 clients.
+                type: int
+            allow_unknown:
+                description: >
+                    Disable to allow leases only for known IPv4 clients, those for which a fixed address is configured.
+                type: bool
+            allow_unknown_v6:
+                description: >
+                    Disable to allow leases only for known IPV6 clients, those for which a fixed address is configured.
+                type: bool
+            echo_client_id:
+                description: >
+                    Enable/disable to include/exclude the client id when responding to discover or request.
+                type: bool
+            filters:
+                description: >
+                    The resource identifier.
+                type: list
+                elements: str
+            filters_v6:
+                description: >
+                    The resource identifier.
+                type: list
+                elements: str
+            ignore_client_uid:
+                description: >
+                    Enable to ignore the client UID when issuing a DHCP lease. Use this option to prevent assigning two IP addresses for a client which does not have a UID during one phase of PXE boot but acquires one for the other phase.
+                type: bool
+            ignore_list:
+                description: >
+                    The list of clients to ignore requests from.
+                type: list
+                elements: dict
+                suboptions:
+                    type:
+                        description: >
+                            Type of ignore matching: client to ignore by client identifier (client hex or client text) or hardware to ignore by hardware identifier (MAC address). It can have one of the following values:
+                            * I(client)hex_,
+                            * I(client)text_,
+                            * I(hardware).
+                        type: str
+                    value:
+                        description: >
+                            Value to match.
+                        type: str
+            lease_time:
+                description: >
+                    The lease duration in seconds.
+                type: int
+            lease_time_v6:
+                description: >
+                    The lease duration in seconds for IPV6 clients.
+                type: int
+    dhcp_options:
+        description: >
+            The list of IPv4 DHCP options for IP space. May be either a specific option or a group of options.
+        type: list
+        elements: dict
+        suboptions:
+            group:
+                description: >
+                    The resource identifier.
+                type: str
+            option_code:
+                description: >
+                    The resource identifier.
+                type: str
+            option_value:
+                description: >
+                    The option value.
+                type: str
+            type:
+                description: >
+                    The type of item.
+                    
+                    Valid values are:
+                    * I(group)
+                    * I(option)
+                type: str
+    dhcp_options_v6:
+        description: >
+            The list of IPv6 DHCP options for IP space. May be either a specific option or a group of options.
+        type: list
+        elements: dict
+        suboptions:
+            group:
+                description: >
+                    The resource identifier.
+                type: str
+            option_code:
+                description: >
+                    The resource identifier.
+                type: str
+            option_value:
+                description: >
+                    The option value.
+                type: str
+            type:
+                description: >
+                    The type of item.
+                    
+                    Valid values are:
+                    * I(group)
+                    * I(option)
+                type: str
+    header_option_filename:
+        description: >
+            The configuration for header option filename field.
+        type: str
+    header_option_server_address:
+        description: >
+            The configuration for header option server address field.
+        type: str
+    header_option_server_name:
+        description: >
+            The configuration for header option server name field.
+        type: str
+    hostname_rewrite_char:
+        description: >
+            The character to replace non-matching characters with, when hostname rewrite is enabled.
+            
+            Any single ASCII character or no character if the invalid characters should be removed without replacement.
+            
+            Defaults to "-".
+        type: str
+    hostname_rewrite_enabled:
+        description: >
+            Indicates if client supplied hostnames will be rewritten prior to DDNS update by replacing every character that does not match I(hostname)rewriteI(regex) by I(hostname)rewriteI(char).
+            
+            Defaults to I(false).
+        type: bool
+    hostname_rewrite_regex:
+        description: >
+            The regex bracket expression to match valid characters.
+            
+            Must begin with "[" and end with "]" and be a compilable POSIX regex.
+            
+            Defaults to "[^a-zA-Z0-9_.]".
+        type: str
+    inheritance_sources:
+        description: >
+            The inheritance configuration.
+        type: dict
+        suboptions:
+            asm_config:
+                description: >
+                    The inheritance configuration for I(asm)config_ field.
+                type: dict
+                suboptions:
+                    asm_enable_block:
+                        description: >
+                            The block of ASM fields: I(enable), I(enable)notificationI(, )reenableI(date).
+                        type: dict
+                        suboptions:
+                            action:
+                                description: >
+                                    The inheritance setting.
+                                    
+                                    Valid values are:
+                                    * I(inherit): Use the inherited value.
+                                    * I(override): Use the value set in the object.
+                                    
+                                    Defaults to I(inherit).
+                                type: str
+                    asm_growth_block:
+                        description: >
+                            The block of ASM fields: I(growth)factorI(, )growthI(type).
+                        type: dict
+                        suboptions:
+                            action:
+                                description: >
+                                    The inheritance setting.
+                                    
+                                    Valid values are:
+                                    * I(inherit): Use the inherited value.
+                                    * I(override): Use the value set in the object.
+                                    
+                                    Defaults to I(inherit).
+                                type: str
+                    asm_threshold:
+                        description: >
+                            ASM shows the number of addresses forecast to be used I(forecast)periodI( days in the future, if it is greater than )asmI(threshold)percentI( * )dhcpI(total) (see I(dhcp)utilization_) then the subnet is flagged.
+                        type: dict
+                        suboptions:
+                            action:
+                                description: >
+                                    The inheritance setting for a field.
+                                    
+                                    Valid values are:
+                                    * I(inherit): Use the inherited value.
+                                    * I(override): Use the value set in the object.
+                                    
+                                    Defaults to I(inherit).
+                                type: str
+                    forecast_period:
+                        description: >
+                            The forecast period in days.
+                        type: dict
+                        suboptions:
+                            action:
+                                description: >
+                                    The inheritance setting for a field.
+                                    
+                                    Valid values are:
+                                    * I(inherit): Use the inherited value.
+                                    * I(override): Use the value set in the object.
+                                    
+                                    Defaults to I(inherit).
+                                type: str
+                    history:
+                        description: >
+                            The minimum amount of history needed before ASM can run on this subnet.
+                        type: dict
+                        suboptions:
+                            action:
+                                description: >
+                                    The inheritance setting for a field.
+                                    
+                                    Valid values are:
+                                    * I(inherit): Use the inherited value.
+                                    * I(override): Use the value set in the object.
+                                    
+                                    Defaults to I(inherit).
+                                type: str
+                    min_total:
+                        description: >
+                            The minimum size of range needed for ASM to run on this subnet.
+                        type: dict
+                        suboptions:
+                            action:
+                                description: >
+                                    The inheritance setting for a field.
+                                    
+                                    Valid values are:
+                                    * I(inherit): Use the inherited value.
+                                    * I(override): Use the value set in the object.
+                                    
+                                    Defaults to I(inherit).
+                                type: str
+                    min_unused:
+                        description: >
+                            The minimum percentage of addresses that must be available outside of the DHCP ranges and fixed addresses when making a suggested change.
+                        type: dict
+                        suboptions:
+                            action:
+                                description: >
+                                    The inheritance setting for a field.
+                                    
+                                    Valid values are:
+                                    * I(inherit): Use the inherited value.
+                                    * I(override): Use the value set in the object.
+                                    
+                                    Defaults to I(inherit).
+                                type: str
+            ddns_client_update:
+                description: >
+                    The inheritance configuration for I(ddns)clientI(update) field from I(IPSpace) object.
+                type: dict
+                suboptions:
+                    action:
+                        description: >
+                            The inheritance setting for a field.
+                            
+                            Valid values are:
+                            * I(inherit): Use the inherited value.
+                            * I(override): Use the value set in the object.
+                            
+                            Defaults to I(inherit).
+                        type: str
+            ddns_conflict_resolution_mode:
+                description: >
+                    The inheritance configuration for I(ddns)conflictI(resolution)modeI( field from )IPSpace_ object.
+                type: dict
+                suboptions:
+                    action:
+                        description: >
+                            The inheritance setting for a field.
+                            
+                            Valid values are:
+                            * I(inherit): Use the inherited value.
+                            * I(override): Use the value set in the object.
+                            
+                            Defaults to I(inherit).
+                        type: str
+            ddns_enabled:
+                description: >
+                    The inheritance configuration for I(ddns)enabled_ field. Only action allowed is 'inherit'.
+                type: dict
+                suboptions:
+                    action:
+                        description: >
+                            The inheritance setting for a field.
+                            
+                            Valid values are:
+                            * I(inherit): Use the inherited value.
+                            * I(override): Use the value set in the object.
+                            
+                            Defaults to I(inherit).
+                        type: str
+            ddns_hostname_block:
+                description: >
+                    The inheritance configuration for I(ddns)generateI(name) and I(ddns)generatedI(prefix) fields from I(IPSpace) object.
+                type: dict
+                suboptions:
+                    action:
+                        description: >
+                            The inheritance setting.
+                            
+                            Valid values are:
+                            * I(inherit): Use the inherited value.
+                            * I(override): Use the value set in the object.
+                            
+                            Defaults to I(inherit).
+                        type: str
+            ddns_ttl_percent:
+                description: >
+                    The inheritance configuration for I(ddns)ttlI(percent) field from I(IPSpace) object.
+                type: dict
+                suboptions:
+                    action:
+                        description: >
+                            The inheritance setting for a field.
+                            
+                            Valid values are:
+                            * I(inherit): Use the inherited value.
+                            * I(override): Use the value set in the object.
+                            
+                            Defaults to I(inherit).
+                        type: str
+            ddns_update_block:
+                description: >
+                    The inheritance configuration for I(ddns)sendI(updates) and I(ddns)domainI( fields from )IPSpace_ object.
+                type: dict
+                suboptions:
+                    action:
+                        description: >
+                            The inheritance setting.
+                            
+                            Valid values are:
+                            * I(inherit): Use the inherited value.
+                            * I(override): Use the value set in the object.
+                            
+                            Defaults to I(inherit).
+                        type: str
+            ddns_update_on_renew:
+                description: >
+                    The inheritance configuration for I(ddns)updateI(on)renewI( field from )IPSpace_ object.
+                type: dict
+                suboptions:
+                    action:
+                        description: >
+                            The inheritance setting for a field.
+                            
+                            Valid values are:
+                            * I(inherit): Use the inherited value.
+                            * I(override): Use the value set in the object.
+                            
+                            Defaults to I(inherit).
+                        type: str
+            ddns_use_conflict_resolution:
+                description: >
+                    The inheritance configuration for I(ddns)useI(conflict)resolutionI( field from )IPSpace_ object.
+                type: dict
+                suboptions:
+                    action:
+                        description: >
+                            The inheritance setting for a field.
+                            
+                            Valid values are:
+                            * I(inherit): Use the inherited value.
+                            * I(override): Use the value set in the object.
+                            
+                            Defaults to I(inherit).
+                        type: str
+            dhcp_config:
+                description: >
+                    The inheritance configuration for I(dhcp)config_ field.
+                type: dict
+                suboptions:
+                    abandoned_reclaim_time:
+                        description: >
+                            The inheritance configuration for I(abandoned)reclaimI(time) field from I(DHCPConfig) object.
+                        type: dict
+                        suboptions:
+                            action:
+                                description: >
+                                    The inheritance setting for a field.
+                                    
+                                    Valid values are:
+                                    * I(inherit): Use the inherited value.
+                                    * I(override): Use the value set in the object.
+                                    
+                                    Defaults to I(inherit).
+                                type: str
+                    abandoned_reclaim_time_v6:
+                        description: >
+                            The inheritance configuration for I(abandoned)reclaimI(time)v6I( field from )DHCPConfig_ object.
+                        type: dict
+                        suboptions:
+                            action:
+                                description: >
+                                    The inheritance setting for a field.
+                                    
+                                    Valid values are:
+                                    * I(inherit): Use the inherited value.
+                                    * I(override): Use the value set in the object.
+                                    
+                                    Defaults to I(inherit).
+                                type: str
+                    allow_unknown:
+                        description: >
+                            The inheritance configuration for I(allow)unknownI( field from )DHCPConfig_ object.
+                        type: dict
+                        suboptions:
+                            action:
+                                description: >
+                                    The inheritance setting for a field.
+                                    
+                                    Valid values are:
+                                    * I(inherit): Use the inherited value.
+                                    * I(override): Use the value set in the object.
+                                    
+                                    Defaults to I(inherit).
+                                type: str
+                    allow_unknown_v6:
+                        description: >
+                            The inheritance configuration for I(allow)unknownI(v6) field from I(DHCPConfig) object.
+                        type: dict
+                        suboptions:
+                            action:
+                                description: >
+                                    The inheritance setting for a field.
+                                    
+                                    Valid values are:
+                                    * I(inherit): Use the inherited value.
+                                    * I(override): Use the value set in the object.
+                                    
+                                    Defaults to I(inherit).
+                                type: str
+                    echo_client_id:
+                        description: >
+                            The inheritance configuration for I(echo)clientI(id) field from I(DHCPConfig) object.
+                        type: dict
+                        suboptions:
+                            action:
+                                description: >
+                                    The inheritance setting for a field.
+                                    
+                                    Valid values are:
+                                    * I(inherit): Use the inherited value.
+                                    * I(override): Use the value set in the object.
+                                    
+                                    Defaults to I(inherit).
+                                type: str
+                    filters:
+                        description: >
+                            The inheritance configuration for filters field from I(DHCPConfig) object.
+                        type: dict
+                        suboptions:
+                            action:
+                                description: >
+                                    The inheritance setting.
+                                    
+                                    Valid values are:
+                                    * I(inherit): Use the inherited value.
+                                    * I(override): Use the value set in the object.
+                                    
+                                    Defaults to I(inherit).
+                                type: str
+                            value:
+                                description: >
+                                    The resource identifier.
+                                type: list
+                                elements: str
+                    filters_v6:
+                        description: >
+                            The inheritance configuration for I(filters)v6I( field from )DHCPConfig_ object.
+                        type: dict
+                        suboptions:
+                            action:
+                                description: >
+                                    The inheritance setting.
+                                    
+                                    Valid values are:
+                                    * I(inherit): Use the inherited value.
+                                    * I(override): Use the value set in the object.
+                                    
+                                    Defaults to I(inherit).
+                                type: str
+                            value:
+                                description: >
+                                    The resource identifier.
+                                type: list
+                                elements: str
+                    ignore_client_uid:
+                        description: >
+                            The inheritance configuration for I(ignore)clientI(uid) field from I(DHCPConfig) object.
+                        type: dict
+                        suboptions:
+                            action:
+                                description: >
+                                    The inheritance setting for a field.
+                                    
+                                    Valid values are:
+                                    * I(inherit): Use the inherited value.
+                                    * I(override): Use the value set in the object.
+                                    
+                                    Defaults to I(inherit).
+                                type: str
+                    ignore_list:
+                        description: >
+                            The inheritance configuration for I(ignore)listI( field from )DHCPConfig_ object.
+                        type: dict
+                        suboptions:
+                            action:
+                                description: >
+                                    The inheritance setting.
+                                    
+                                    Valid values are:
+                                    * I(inherit): Use the inherited value.
+                                    * I(override): Use the value set in the object.
+                                    
+                                    Defaults to I(inherit).
+                                type: str
+                    lease_time:
+                        description: >
+                            The inheritance configuration for I(lease)timeI( field from )DHCPConfig_ object.
+                        type: dict
+                        suboptions:
+                            action:
+                                description: >
+                                    The inheritance setting for a field.
+                                    
+                                    Valid values are:
+                                    * I(inherit): Use the inherited value.
+                                    * I(override): Use the value set in the object.
+                                    
+                                    Defaults to I(inherit).
+                                type: str
+                    lease_time_v6:
+                        description: >
+                            The inheritance configuration for I(lease)timeI(v6) field from I(DHCPConfig) object.
+                        type: dict
+                        suboptions:
+                            action:
+                                description: >
+                                    The inheritance setting for a field.
+                                    
+                                    Valid values are:
+                                    * I(inherit): Use the inherited value.
+                                    * I(override): Use the value set in the object.
+                                    
+                                    Defaults to I(inherit).
+                                type: str
+            dhcp_options:
+                description: >
+                    The inheritance configuration for I(dhcp)options_ field.
+                type: dict
+                suboptions:
+                    action:
+                        description: >
+                            The inheritance setting.
+                            
+                            Valid values are:
+                            * I(inherit): Use the inherited value.
+                            * I(block): Don't use the inherited value.
+                            
+                            Defaults to I(inherit).
+                        type: str
+                    value:
+                        description: >
+                            The inherited DHCP option values.
+                        type: list
+                        elements: dict
+                        suboptions:
+                            action:
+                                description: >
+                                    The inheritance setting.
+                                    
+                                    Valid values are:
+                                    * I(inherit): Use the inherited value.
+                                    * I(block): Don't use the inherited value.
+                                    
+                                    Defaults to I(inherit).
+                                type: str
+            dhcp_options_v6:
+                description: >
+                    The inheritance configuration for I(dhcp)optionsI(v6) field.
+                type: dict
+                suboptions:
+                    action:
+                        description: >
+                            The inheritance setting.
+                            
+                            Valid values are:
+                            * I(inherit): Use the inherited value.
+                            * I(block): Don't use the inherited value.
+                            
+                            Defaults to I(inherit).
+                        type: str
+                    value:
+                        description: >
+                            The inherited DHCP option values.
+                        type: list
+                        elements: dict
+                        suboptions:
+                            action:
+                                description: >
+                                    The inheritance setting.
+                                    
+                                    Valid values are:
+                                    * I(inherit): Use the inherited value.
+                                    * I(block): Don't use the inherited value.
+                                    
+                                    Defaults to I(inherit).
+                                type: str
+            header_option_filename:
+                description: >
+                    The inheritance configuration for I(header)optionI(filename) field.
+                type: dict
+                suboptions:
+                    action:
+                        description: >
+                            The inheritance setting for a field.
+                            
+                            Valid values are:
+                            * I(inherit): Use the inherited value.
+                            * I(override): Use the value set in the object.
+                            
+                            Defaults to I(inherit).
+                        type: str
+            header_option_server_address:
+                description: >
+                    The inheritance configuration for I(header)optionI(server)address_ field.
+                type: dict
+                suboptions:
+                    action:
+                        description: >
+                            The inheritance setting for a field.
+                            
+                            Valid values are:
+                            * I(inherit): Use the inherited value.
+                            * I(override): Use the value set in the object.
+                            
+                            Defaults to I(inherit).
+                        type: str
+            header_option_server_name:
+                description: >
+                    The inheritance configuration for I(header)optionI(server)name_ field.
+                type: dict
+                suboptions:
+                    action:
+                        description: >
+                            The inheritance setting for a field.
+                            
+                            Valid values are:
+                            * I(inherit): Use the inherited value.
+                            * I(override): Use the value set in the object.
+                            
+                            Defaults to I(inherit).
+                        type: str
+            hostname_rewrite_block:
+                description: >
+                    The inheritance configuration for I(hostname)rewriteI(enabled), I(hostname)rewriteI(regex), and I(hostname)rewriteI(char) fields from I(IPSpace) object.
+                type: dict
+                suboptions:
+                    action:
+                        description: >
+                            The inheritance setting.
+                            
+                            Valid values are:
+                            * I(inherit): Use the inherited value.
+                            * I(override): Use the value set in the object.
+                            
+                            Defaults to I(inherit).
+                        type: str
+            vendor_specific_option_option_space:
+                description: >
+                    The inheritance configuration for I(vendor)specificI(option)optionI(space) field.
+                type: dict
+                suboptions:
+                    action:
+                        description: >
+                            The inheritance setting for a field.
+                            
+                            Valid values are:
+                            * I(inherit): Use the inherited value.
+                            * I(override): Use the value set in the object.
+                            
+                            Defaults to I(inherit).
+                        type: str
+                    value:
+                        description: >
+                            The resource identifier.
+                        type: str
+    name:
+        description: >
+            The name of the IP space. Must contain 1 to 256 characters. Can include UTF-8.
+        type: str
+    tags:
+        description: >
+            The tags for the IP space in JSON format.
+        type: dict
+    vendor_specific_option_option_space:
+        description: >
+            The resource identifier.
+        type: str
+
+extends_documentation_fragment:
+    - infoblox.bloxone.common
+"""  # noqa: E501
+
+EXAMPLES = r"""
+  - name: "Create an IP space"
+    infoblox.bloxone.ipam_ip_space:
+      name: "my-ip-space"
+      state: "present"
+
+  - name: "Create an IP space with tags"
+    infoblox.bloxone.ipam_ip_space:
+      name: "my-ip-space"
+      tags:
+        location: "my-location"
+
+  - name: "Delete an IP space"
+    infoblox.bloxone.ipam_ip_space:
+      name: "my-ip-space"
+      state: "absent"
+"""  # noqa: E501
+
+RETURN = r"""
+id:
+    description:
+        - ID of the IpSpace object
+    type: str
+    returned: Always
+item:
+    description:
+        - IpSpace object
+    type: complex
+    returned: Always
+    contains:
+        asm_config:
+            description: >
+                The Automated Scope Management configuration for the IP space.
+            type: dict
+            returned: Always
+            contains:
+                asm_threshold:
+                    description: >
+                        ASM shows the number of addresses forecast to be used I(forecast)periodI( days in the future, if it is greater than )asmI(threshold) percent * I(dhcp)totalI( (see )dhcpI(utilization)) then the subnet is flagged.
+                    type: int
+                    returned: Always
+                enable:
+                    description: >
+                        Indicates if Automated Scope Management is enabled.
+                    type: bool
+                    returned: Always
+                enable_notification:
+                    description: >
+                        Indicates if ASM should send notifications to the user.
+                    type: bool
+                    returned: Always
+                forecast_period:
+                    description: >
+                        The forecast period in days.
+                    type: int
+                    returned: Always
+                growth_factor:
+                    description: >
+                        Indicates the growth in the number or percentage of IP addresses.
+                    type: int
+                    returned: Always
+                growth_type:
+                    description: >
+                        The type of factor to use: I(percent) or I(count).
+                    type: str
+                    returned: Always
+                history:
+                    description: >
+                        The minimum amount of history needed before ASM can run on this subnet.
+                    type: int
+                    returned: Always
+                min_total:
+                    description: >
+                        The minimum size of range needed for ASM to run on this subnet.
+                    type: int
+                    returned: Always
+                min_unused:
+                    description: >
+                        The minimum percentage of addresses that must be available outside of the DHCP ranges and fixed addresses
+                        when making a suggested change..
+                    type: int
+                    returned: Always
+                reenable_date:
+                    description: ""
+                    type: str
+                    returned: Always
+        asm_scope_flag:
+            description: >
+                The number of times the automated scope management usage limits have been exceeded for any of the subnets in this IP space.
+            type: int
+            returned: Always
+        comment:
+            description: >
+                The description for the IP space. May contain 0 to 1024 characters. Can include UTF-8.
+            type: str
+            returned: Always
+        created_at:
+            description: >
+                Time when the object has been created.
+            type: str
+            returned: Always
+        ddns_client_update:
+            description: >
+                Controls who does the DDNS updates.
+                
+                Valid values are:
+                * I(client): DHCP server updates DNS if requested by client.
+                * I(server): DHCP server always updates DNS, overriding an update request from the client, unless the client requests no updates.
+                * I(ignore): DHCP server always updates DNS, even if the client says not to.
+                * I(over)clientI(update): Same as I(server). DHCP server always updates DNS, overriding an update request from the client, unless the client requests no updates.
+                * I(over)noI(update): DHCP server updates DNS even if the client requests that no updates be done. If the client requests to do the update, DHCP server allows it.
+                
+                Defaults to I(client).
+            type: str
+            returned: Always
+        ddns_conflict_resolution_mode:
+            description: >
+                The mode used for resolving conflicts while performing DDNS updates.
+                
+                Valid values are:
+                * I(check)withI(dhcid): It includes adding a DHCID record and checking that record via conflict detection as per RFC 4703.
+                * I(no)checkI(with)dhcid_: This will ignore conflict detection but add a DHCID record when creating/updating an entry.
+                * I(check)existsI(with)dhcid_: This will check if there is an existing DHCID record but does not verify the value of the record matches the update. This will also update the DHCID record for the entry.
+                * I(no)checkI(without)dhcid_: This ignores conflict detection and will not add a DHCID record when creating/updating a DDNS entry.
+                
+                Defaults to I(check)withI(dhcid).
+            type: str
+            returned: Always
+        ddns_domain:
+            description: >
+                The domain suffix for DDNS updates. FQDN, may be empty.
+                
+                Defaults to empty.
+            type: str
+            returned: Always
+        ddns_generate_name:
+            description: >
+                Indicates if DDNS needs to generate a hostname when not supplied by the client.
+                
+                Defaults to I(false).
+            type: bool
+            returned: Always
+        ddns_generated_prefix:
+            description: >
+                The prefix used in the generation of an FQDN.
+                
+                When generating a name, DHCP server will construct the name in the format: [ddns-generated-prefix]-[address-text].[ddns-qualifying-suffix].
+                where address-text is simply the lease IP address converted to a hyphenated string.
+                
+                Defaults to "myhost".
+            type: str
+            returned: Always
+        ddns_send_updates:
+            description: >
+                Determines if DDNS updates are enabled at the IP space level.
+                Defaults to I(true).
+            type: bool
+            returned: Always
+        ddns_ttl_percent:
+            description: >
+                DDNS TTL value - to be calculated as a simple percentage of the lease's lifetime, using the parameter's value as the percentage.
+                It is specified as a percentage (e.g. 25, 75).
+                Defaults to unspecified.
+            type: float
+            returned: Always
+        ddns_update_on_renew:
+            description: >
+                Instructs the DHCP server to always update the DNS information when a lease is renewed even if its DNS information has not changed.
+                
+                Defaults to I(false).
+            type: bool
+            returned: Always
+        ddns_use_conflict_resolution:
+            description: >
+                When true, DHCP server will apply conflict resolution, as described in RFC 4703, when attempting to fulfill the update request.
+                
+                When false, DHCP server will simply attempt to update the DNS entries per the request, regardless of whether or not they conflict with existing entries owned by other DHCP4 clients.
+                
+                Defaults to I(true).
+            type: bool
+            returned: Always
+        dhcp_config:
+            description: >
+                The shared DHCP configuration for the IP space that controls how leases are issued.
+            type: dict
+            returned: Always
+            contains:
+                abandoned_reclaim_time:
+                    description: >
+                        The abandoned reclaim time in seconds for IPV4 clients.
+                    type: int
+                    returned: Always
+                abandoned_reclaim_time_v6:
+                    description: >
+                        The abandoned reclaim time in seconds for IPV6 clients.
+                    type: int
+                    returned: Always
+                allow_unknown:
+                    description: >
+                        Disable to allow leases only for known IPv4 clients, those for which a fixed address is configured.
+                    type: bool
+                    returned: Always
+                allow_unknown_v6:
+                    description: >
+                        Disable to allow leases only for known IPV6 clients, those for which a fixed address is configured.
+                    type: bool
+                    returned: Always
+                echo_client_id:
+                    description: >
+                        Enable/disable to include/exclude the client id when responding to discover or request.
+                    type: bool
+                    returned: Always
+                filters:
+                    description: >
+                        The resource identifier.
+                    type: list
+                    returned: Always
+                filters_v6:
+                    description: >
+                        The resource identifier.
+                    type: list
+                    returned: Always
+                ignore_client_uid:
+                    description: >
+                        Enable to ignore the client UID when issuing a DHCP lease. Use this option to prevent assigning two IP addresses for a client which does not have a UID during one phase of PXE boot but acquires one for the other phase.
+                    type: bool
+                    returned: Always
+                ignore_list:
+                    description: >
+                        The list of clients to ignore requests from.
+                    type: list
+                    returned: Always
+                    elements: dict
+                    contains:
+                        type:
+                            description: >
+                                Type of ignore matching: client to ignore by client identifier (client hex or client text) or hardware to ignore by hardware identifier (MAC address). It can have one of the following values:
+                                * I(client)hex_,
+                                * I(client)text_,
+                                * I(hardware).
+                            type: str
+                            returned: Always
+                        value:
+                            description: >
+                                Value to match.
+                            type: str
+                            returned: Always
+                lease_time:
+                    description: >
+                        The lease duration in seconds.
+                    type: int
+                    returned: Always
+                lease_time_v6:
+                    description: >
+                        The lease duration in seconds for IPV6 clients.
+                    type: int
+                    returned: Always
+        dhcp_options:
+            description: >
+                The list of IPv4 DHCP options for IP space. May be either a specific option or a group of options.
+            type: list
+            returned: Always
+            elements: dict
+            contains:
+                group:
+                    description: >
+                        The resource identifier.
+                    type: str
+                    returned: Always
+                option_code:
+                    description: >
+                        The resource identifier.
+                    type: str
+                    returned: Always
+                option_value:
+                    description: >
+                        The option value.
+                    type: str
+                    returned: Always
+                type:
+                    description: >
+                        The type of item.
+                        
+                        Valid values are:
+                        * I(group)
+                        * I(option)
+                    type: str
+                    returned: Always
+        dhcp_options_v6:
+            description: >
+                The list of IPv6 DHCP options for IP space. May be either a specific option or a group of options.
+            type: list
+            returned: Always
+            elements: dict
+            contains:
+                group:
+                    description: >
+                        The resource identifier.
+                    type: str
+                    returned: Always
+                option_code:
+                    description: >
+                        The resource identifier.
+                    type: str
+                    returned: Always
+                option_value:
+                    description: >
+                        The option value.
+                    type: str
+                    returned: Always
+                type:
+                    description: >
+                        The type of item.
+                        
+                        Valid values are:
+                        * I(group)
+                        * I(option)
+                    type: str
+                    returned: Always
+        header_option_filename:
+            description: >
+                The configuration for header option filename field.
+            type: str
+            returned: Always
+        header_option_server_address:
+            description: >
+                The configuration for header option server address field.
+            type: str
+            returned: Always
+        header_option_server_name:
+            description: >
+                The configuration for header option server name field.
+            type: str
+            returned: Always
+        hostname_rewrite_char:
+            description: >
+                The character to replace non-matching characters with, when hostname rewrite is enabled.
+                
+                Any single ASCII character or no character if the invalid characters should be removed without replacement.
+                
+                Defaults to "-".
+            type: str
+            returned: Always
+        hostname_rewrite_enabled:
+            description: >
+                Indicates if client supplied hostnames will be rewritten prior to DDNS update by replacing every character that does not match I(hostname)rewriteI(regex) by I(hostname)rewriteI(char).
+                
+                Defaults to I(false).
+            type: bool
+            returned: Always
+        hostname_rewrite_regex:
+            description: >
+                The regex bracket expression to match valid characters.
+                
+                Must begin with "[" and end with "]" and be a compilable POSIX regex.
+                
+                Defaults to "[^a-zA-Z0-9_.]".
+            type: str
+            returned: Always
+        id:
+            description: >
+                The resource identifier.
+            type: str
+            returned: Always
+        inheritance_sources:
+            description: >
+                The inheritance configuration.
+            type: dict
+            returned: Always
+            contains:
+                asm_config:
+                    description: >
+                        The inheritance configuration for I(asm)config_ field.
+                    type: dict
+                    returned: Always
+                    contains:
+                        asm_enable_block:
+                            description: >
+                                The block of ASM fields: I(enable), I(enable)notificationI(, )reenableI(date).
+                            type: dict
+                            returned: Always
+                            contains:
+                                action:
+                                    description: >
+                                        The inheritance setting.
+                                        
+                                        Valid values are:
+                                        * I(inherit): Use the inherited value.
+                                        * I(override): Use the value set in the object.
+                                        
+                                        Defaults to I(inherit).
+                                    type: str
+                                    returned: Always
+                                display_name:
+                                    description: >
+                                        The human-readable display name for the object referred to by I(source).
+                                    type: str
+                                    returned: Always
+                                source:
+                                    description: >
+                                        The resource identifier.
+                                    type: str
+                                    returned: Always
+                                value:
+                                    description: >
+                                        The inherited value.
+                                    type: dict
+                                    returned: Always
+                                    contains:
+                                        enable:
+                                            description: >
+                                                Indicates whether Automated Scope Management is enabled or not.
+                                            type: bool
+                                            returned: Always
+                                        enable_notification:
+                                            description: >
+                                                Indicates whether sending notifications to the users is enabled or not.
+                                            type: bool
+                                            returned: Always
+                                        reenable_date:
+                                            description: >
+                                                The date at which notifications will be re-enabled automatically.
+                                            type: str
+                                            returned: Always
+                        asm_growth_block:
+                            description: >
+                                The block of ASM fields: I(growth)factorI(, )growthI(type).
+                            type: dict
+                            returned: Always
+                            contains:
+                                action:
+                                    description: >
+                                        The inheritance setting.
+                                        
+                                        Valid values are:
+                                        * I(inherit): Use the inherited value.
+                                        * I(override): Use the value set in the object.
+                                        
+                                        Defaults to I(inherit).
+                                    type: str
+                                    returned: Always
+                                display_name:
+                                    description: >
+                                        The human-readable display name for the object referred to by I(source).
+                                    type: str
+                                    returned: Always
+                                source:
+                                    description: >
+                                        The resource identifier.
+                                    type: str
+                                    returned: Always
+                                value:
+                                    description: >
+                                        The inherited value.
+                                    type: dict
+                                    returned: Always
+                                    contains:
+                                        growth_factor:
+                                            description: >
+                                                Either the number or percentage of addresses to grow by.
+                                            type: int
+                                            returned: Always
+                                        growth_type:
+                                            description: >
+                                                The type of factor to use: I(percent) or I(count).
+                                            type: str
+                                            returned: Always
+                        asm_threshold:
+                            description: >
+                                ASM shows the number of addresses forecast to be used I(forecast)periodI( days in the future, if it is greater than )asmI(threshold)percentI( * )dhcpI(total) (see I(dhcp)utilization_) then the subnet is flagged.
+                            type: dict
+                            returned: Always
+                            contains:
+                                action:
+                                    description: >
+                                        The inheritance setting for a field.
+                                        
+                                        Valid values are:
+                                        * I(inherit): Use the inherited value.
+                                        * I(override): Use the value set in the object.
+                                        
+                                        Defaults to I(inherit).
+                                    type: str
+                                    returned: Always
+                                display_name:
+                                    description: >
+                                        The human-readable display name for the object referred to by I(source).
+                                    type: str
+                                    returned: Always
+                                source:
+                                    description: >
+                                        The resource identifier.
+                                    type: str
+                                    returned: Always
+                                value:
+                                    description: >
+                                        The inherited value.
+                                    type: int
+                                    returned: Always
+                        forecast_period:
+                            description: >
+                                The forecast period in days.
+                            type: dict
+                            returned: Always
+                            contains:
+                                action:
+                                    description: >
+                                        The inheritance setting for a field.
+                                        
+                                        Valid values are:
+                                        * I(inherit): Use the inherited value.
+                                        * I(override): Use the value set in the object.
+                                        
+                                        Defaults to I(inherit).
+                                    type: str
+                                    returned: Always
+                                display_name:
+                                    description: >
+                                        The human-readable display name for the object referred to by I(source).
+                                    type: str
+                                    returned: Always
+                                source:
+                                    description: >
+                                        The resource identifier.
+                                    type: str
+                                    returned: Always
+                                value:
+                                    description: >
+                                        The inherited value.
+                                    type: int
+                                    returned: Always
+                        history:
+                            description: >
+                                The minimum amount of history needed before ASM can run on this subnet.
+                            type: dict
+                            returned: Always
+                            contains:
+                                action:
+                                    description: >
+                                        The inheritance setting for a field.
+                                        
+                                        Valid values are:
+                                        * I(inherit): Use the inherited value.
+                                        * I(override): Use the value set in the object.
+                                        
+                                        Defaults to I(inherit).
+                                    type: str
+                                    returned: Always
+                                display_name:
+                                    description: >
+                                        The human-readable display name for the object referred to by I(source).
+                                    type: str
+                                    returned: Always
+                                source:
+                                    description: >
+                                        The resource identifier.
+                                    type: str
+                                    returned: Always
+                                value:
+                                    description: >
+                                        The inherited value.
+                                    type: int
+                                    returned: Always
+                        min_total:
+                            description: >
+                                The minimum size of range needed for ASM to run on this subnet.
+                            type: dict
+                            returned: Always
+                            contains:
+                                action:
+                                    description: >
+                                        The inheritance setting for a field.
+                                        
+                                        Valid values are:
+                                        * I(inherit): Use the inherited value.
+                                        * I(override): Use the value set in the object.
+                                        
+                                        Defaults to I(inherit).
+                                    type: str
+                                    returned: Always
+                                display_name:
+                                    description: >
+                                        The human-readable display name for the object referred to by I(source).
+                                    type: str
+                                    returned: Always
+                                source:
+                                    description: >
+                                        The resource identifier.
+                                    type: str
+                                    returned: Always
+                                value:
+                                    description: >
+                                        The inherited value.
+                                    type: int
+                                    returned: Always
+                        min_unused:
+                            description: >
+                                The minimum percentage of addresses that must be available outside of the DHCP ranges and fixed addresses when making a suggested change.
+                            type: dict
+                            returned: Always
+                            contains:
+                                action:
+                                    description: >
+                                        The inheritance setting for a field.
+                                        
+                                        Valid values are:
+                                        * I(inherit): Use the inherited value.
+                                        * I(override): Use the value set in the object.
+                                        
+                                        Defaults to I(inherit).
+                                    type: str
+                                    returned: Always
+                                display_name:
+                                    description: >
+                                        The human-readable display name for the object referred to by I(source).
+                                    type: str
+                                    returned: Always
+                                source:
+                                    description: >
+                                        The resource identifier.
+                                    type: str
+                                    returned: Always
+                                value:
+                                    description: >
+                                        The inherited value.
+                                    type: int
+                                    returned: Always
+                ddns_client_update:
+                    description: >
+                        The inheritance configuration for I(ddns)clientI(update) field from I(IPSpace) object.
+                    type: dict
+                    returned: Always
+                    contains:
+                        action:
+                            description: >
+                                The inheritance setting for a field.
+                                
+                                Valid values are:
+                                * I(inherit): Use the inherited value.
+                                * I(override): Use the value set in the object.
+                                
+                                Defaults to I(inherit).
+                            type: str
+                            returned: Always
+                        display_name:
+                            description: >
+                                The human-readable display name for the object referred to by I(source).
+                            type: str
+                            returned: Always
+                        source:
+                            description: >
+                                The resource identifier.
+                            type: str
+                            returned: Always
+                        value:
+                            description: >
+                                The inherited value.
+                            type: str
+                            returned: Always
+                ddns_conflict_resolution_mode:
+                    description: >
+                        The inheritance configuration for I(ddns)conflictI(resolution)modeI( field from )IPSpace_ object.
+                    type: dict
+                    returned: Always
+                    contains:
+                        action:
+                            description: >
+                                The inheritance setting for a field.
+                                
+                                Valid values are:
+                                * I(inherit): Use the inherited value.
+                                * I(override): Use the value set in the object.
+                                
+                                Defaults to I(inherit).
+                            type: str
+                            returned: Always
+                        display_name:
+                            description: >
+                                The human-readable display name for the object referred to by I(source).
+                            type: str
+                            returned: Always
+                        source:
+                            description: >
+                                The resource identifier.
+                            type: str
+                            returned: Always
+                        value:
+                            description: >
+                                The inherited value.
+                            type: str
+                            returned: Always
+                ddns_enabled:
+                    description: >
+                        The inheritance configuration for I(ddns)enabled_ field. Only action allowed is 'inherit'.
+                    type: dict
+                    returned: Always
+                    contains:
+                        action:
+                            description: >
+                                The inheritance setting for a field.
+                                
+                                Valid values are:
+                                * I(inherit): Use the inherited value.
+                                * I(override): Use the value set in the object.
+                                
+                                Defaults to I(inherit).
+                            type: str
+                            returned: Always
+                        display_name:
+                            description: >
+                                The human-readable display name for the object referred to by I(source).
+                            type: str
+                            returned: Always
+                        source:
+                            description: >
+                                The resource identifier.
+                            type: str
+                            returned: Always
+                        value:
+                            description: >
+                                The inherited value.
+                            type: bool
+                            returned: Always
+                ddns_hostname_block:
+                    description: >
+                        The inheritance configuration for I(ddns)generateI(name) and I(ddns)generatedI(prefix) fields from I(IPSpace) object.
+                    type: dict
+                    returned: Always
+                    contains:
+                        action:
+                            description: >
+                                The inheritance setting.
+                                
+                                Valid values are:
+                                * I(inherit): Use the inherited value.
+                                * I(override): Use the value set in the object.
+                                
+                                Defaults to I(inherit).
+                            type: str
+                            returned: Always
+                        display_name:
+                            description: >
+                                The human-readable display name for the object referred to by I(source).
+                            type: str
+                            returned: Always
+                        source:
+                            description: >
+                                The resource identifier.
+                            type: str
+                            returned: Always
+                        value:
+                            description: >
+                                The inherited value.
+                            type: dict
+                            returned: Always
+                            contains:
+                                ddns_generate_name:
+                                    description: >
+                                        Indicates if DDNS should generate a hostname when not supplied by the client.
+                                    type: bool
+                                    returned: Always
+                                ddns_generated_prefix:
+                                    description: >
+                                        The prefix used in the generation of an FQDN.
+                                    type: str
+                                    returned: Always
+                ddns_ttl_percent:
+                    description: >
+                        The inheritance configuration for I(ddns)ttlI(percent) field from I(IPSpace) object.
+                    type: dict
+                    returned: Always
+                    contains:
+                        action:
+                            description: >
+                                The inheritance setting for a field.
+                                
+                                Valid values are:
+                                * I(inherit): Use the inherited value.
+                                * I(override): Use the value set in the object.
+                                
+                                Defaults to I(inherit).
+                            type: str
+                            returned: Always
+                        display_name:
+                            description: >
+                                The human-readable display name for the object referred to by I(source).
+                            type: str
+                            returned: Always
+                        source:
+                            description: >
+                                The resource identifier.
+                            type: str
+                            returned: Always
+                        value:
+                            description: >
+                                The inherited value.
+                            type: float
+                            returned: Always
+                ddns_update_block:
+                    description: >
+                        The inheritance configuration for I(ddns)sendI(updates) and I(ddns)domainI( fields from )IPSpace_ object.
+                    type: dict
+                    returned: Always
+                    contains:
+                        action:
+                            description: >
+                                The inheritance setting.
+                                
+                                Valid values are:
+                                * I(inherit): Use the inherited value.
+                                * I(override): Use the value set in the object.
+                                
+                                Defaults to I(inherit).
+                            type: str
+                            returned: Always
+                        display_name:
+                            description: >
+                                The human-readable display name for the object referred to by I(source).
+                            type: str
+                            returned: Always
+                        source:
+                            description: >
+                                The resource identifier.
+                            type: str
+                            returned: Always
+                        value:
+                            description: >
+                                The inherited value.
+                            type: dict
+                            returned: Always
+                            contains:
+                                ddns_domain:
+                                    description: >
+                                        The domain name for DDNS.
+                                    type: str
+                                    returned: Always
+                                ddns_send_updates:
+                                    description: >
+                                        Determines if DDNS updates are enabled at this level.
+                                    type: bool
+                                    returned: Always
+                ddns_update_on_renew:
+                    description: >
+                        The inheritance configuration for I(ddns)updateI(on)renewI( field from )IPSpace_ object.
+                    type: dict
+                    returned: Always
+                    contains:
+                        action:
+                            description: >
+                                The inheritance setting for a field.
+                                
+                                Valid values are:
+                                * I(inherit): Use the inherited value.
+                                * I(override): Use the value set in the object.
+                                
+                                Defaults to I(inherit).
+                            type: str
+                            returned: Always
+                        display_name:
+                            description: >
+                                The human-readable display name for the object referred to by I(source).
+                            type: str
+                            returned: Always
+                        source:
+                            description: >
+                                The resource identifier.
+                            type: str
+                            returned: Always
+                        value:
+                            description: >
+                                The inherited value.
+                            type: bool
+                            returned: Always
+                ddns_use_conflict_resolution:
+                    description: >
+                        The inheritance configuration for I(ddns)useI(conflict)resolutionI( field from )IPSpace_ object.
+                    type: dict
+                    returned: Always
+                    contains:
+                        action:
+                            description: >
+                                The inheritance setting for a field.
+                                
+                                Valid values are:
+                                * I(inherit): Use the inherited value.
+                                * I(override): Use the value set in the object.
+                                
+                                Defaults to I(inherit).
+                            type: str
+                            returned: Always
+                        display_name:
+                            description: >
+                                The human-readable display name for the object referred to by I(source).
+                            type: str
+                            returned: Always
+                        source:
+                            description: >
+                                The resource identifier.
+                            type: str
+                            returned: Always
+                        value:
+                            description: >
+                                The inherited value.
+                            type: bool
+                            returned: Always
+                dhcp_config:
+                    description: >
+                        The inheritance configuration for I(dhcp)config_ field.
+                    type: dict
+                    returned: Always
+                    contains:
+                        abandoned_reclaim_time:
+                            description: >
+                                The inheritance configuration for I(abandoned)reclaimI(time) field from I(DHCPConfig) object.
+                            type: dict
+                            returned: Always
+                            contains:
+                                action:
+                                    description: >
+                                        The inheritance setting for a field.
+                                        
+                                        Valid values are:
+                                        * I(inherit): Use the inherited value.
+                                        * I(override): Use the value set in the object.
+                                        
+                                        Defaults to I(inherit).
+                                    type: str
+                                    returned: Always
+                                display_name:
+                                    description: >
+                                        The human-readable display name for the object referred to by I(source).
+                                    type: str
+                                    returned: Always
+                                source:
+                                    description: >
+                                        The resource identifier.
+                                    type: str
+                                    returned: Always
+                                value:
+                                    description: >
+                                        The inherited value.
+                                    type: int
+                                    returned: Always
+                        abandoned_reclaim_time_v6:
+                            description: >
+                                The inheritance configuration for I(abandoned)reclaimI(time)v6I( field from )DHCPConfig_ object.
+                            type: dict
+                            returned: Always
+                            contains:
+                                action:
+                                    description: >
+                                        The inheritance setting for a field.
+                                        
+                                        Valid values are:
+                                        * I(inherit): Use the inherited value.
+                                        * I(override): Use the value set in the object.
+                                        
+                                        Defaults to I(inherit).
+                                    type: str
+                                    returned: Always
+                                display_name:
+                                    description: >
+                                        The human-readable display name for the object referred to by I(source).
+                                    type: str
+                                    returned: Always
+                                source:
+                                    description: >
+                                        The resource identifier.
+                                    type: str
+                                    returned: Always
+                                value:
+                                    description: >
+                                        The inherited value.
+                                    type: int
+                                    returned: Always
+                        allow_unknown:
+                            description: >
+                                The inheritance configuration for I(allow)unknownI( field from )DHCPConfig_ object.
+                            type: dict
+                            returned: Always
+                            contains:
+                                action:
+                                    description: >
+                                        The inheritance setting for a field.
+                                        
+                                        Valid values are:
+                                        * I(inherit): Use the inherited value.
+                                        * I(override): Use the value set in the object.
+                                        
+                                        Defaults to I(inherit).
+                                    type: str
+                                    returned: Always
+                                display_name:
+                                    description: >
+                                        The human-readable display name for the object referred to by I(source).
+                                    type: str
+                                    returned: Always
+                                source:
+                                    description: >
+                                        The resource identifier.
+                                    type: str
+                                    returned: Always
+                                value:
+                                    description: >
+                                        The inherited value.
+                                    type: bool
+                                    returned: Always
+                        allow_unknown_v6:
+                            description: >
+                                The inheritance configuration for I(allow)unknownI(v6) field from I(DHCPConfig) object.
+                            type: dict
+                            returned: Always
+                            contains:
+                                action:
+                                    description: >
+                                        The inheritance setting for a field.
+                                        
+                                        Valid values are:
+                                        * I(inherit): Use the inherited value.
+                                        * I(override): Use the value set in the object.
+                                        
+                                        Defaults to I(inherit).
+                                    type: str
+                                    returned: Always
+                                display_name:
+                                    description: >
+                                        The human-readable display name for the object referred to by I(source).
+                                    type: str
+                                    returned: Always
+                                source:
+                                    description: >
+                                        The resource identifier.
+                                    type: str
+                                    returned: Always
+                                value:
+                                    description: >
+                                        The inherited value.
+                                    type: bool
+                                    returned: Always
+                        echo_client_id:
+                            description: >
+                                The inheritance configuration for I(echo)clientI(id) field from I(DHCPConfig) object.
+                            type: dict
+                            returned: Always
+                            contains:
+                                action:
+                                    description: >
+                                        The inheritance setting for a field.
+                                        
+                                        Valid values are:
+                                        * I(inherit): Use the inherited value.
+                                        * I(override): Use the value set in the object.
+                                        
+                                        Defaults to I(inherit).
+                                    type: str
+                                    returned: Always
+                                display_name:
+                                    description: >
+                                        The human-readable display name for the object referred to by I(source).
+                                    type: str
+                                    returned: Always
+                                source:
+                                    description: >
+                                        The resource identifier.
+                                    type: str
+                                    returned: Always
+                                value:
+                                    description: >
+                                        The inherited value.
+                                    type: bool
+                                    returned: Always
+                        filters:
+                            description: >
+                                The inheritance configuration for filters field from I(DHCPConfig) object.
+                            type: dict
+                            returned: Always
+                            contains:
+                                action:
+                                    description: >
+                                        The inheritance setting.
+                                        
+                                        Valid values are:
+                                        * I(inherit): Use the inherited value.
+                                        * I(override): Use the value set in the object.
+                                        
+                                        Defaults to I(inherit).
+                                    type: str
+                                    returned: Always
+                                display_name:
+                                    description: >
+                                        The human-readable display name for the object referred to by I(source).
+                                    type: str
+                                    returned: Always
+                                source:
+                                    description: >
+                                        The resource identifier.
+                                    type: str
+                                    returned: Always
+                                value:
+                                    description: >
+                                        The resource identifier.
+                                    type: list
+                                    returned: Always
+                        filters_v6:
+                            description: >
+                                The inheritance configuration for I(filters)v6I( field from )DHCPConfig_ object.
+                            type: dict
+                            returned: Always
+                            contains:
+                                action:
+                                    description: >
+                                        The inheritance setting.
+                                        
+                                        Valid values are:
+                                        * I(inherit): Use the inherited value.
+                                        * I(override): Use the value set in the object.
+                                        
+                                        Defaults to I(inherit).
+                                    type: str
+                                    returned: Always
+                                display_name:
+                                    description: >
+                                        The human-readable display name for the object referred to by I(source).
+                                    type: str
+                                    returned: Always
+                                source:
+                                    description: >
+                                        The resource identifier.
+                                    type: str
+                                    returned: Always
+                                value:
+                                    description: >
+                                        The resource identifier.
+                                    type: list
+                                    returned: Always
+                        ignore_client_uid:
+                            description: >
+                                The inheritance configuration for I(ignore)clientI(uid) field from I(DHCPConfig) object.
+                            type: dict
+                            returned: Always
+                            contains:
+                                action:
+                                    description: >
+                                        The inheritance setting for a field.
+                                        
+                                        Valid values are:
+                                        * I(inherit): Use the inherited value.
+                                        * I(override): Use the value set in the object.
+                                        
+                                        Defaults to I(inherit).
+                                    type: str
+                                    returned: Always
+                                display_name:
+                                    description: >
+                                        The human-readable display name for the object referred to by I(source).
+                                    type: str
+                                    returned: Always
+                                source:
+                                    description: >
+                                        The resource identifier.
+                                    type: str
+                                    returned: Always
+                                value:
+                                    description: >
+                                        The inherited value.
+                                    type: bool
+                                    returned: Always
+                        ignore_list:
+                            description: >
+                                The inheritance configuration for I(ignore)listI( field from )DHCPConfig_ object.
+                            type: dict
+                            returned: Always
+                            contains:
+                                action:
+                                    description: >
+                                        The inheritance setting.
+                                        
+                                        Valid values are:
+                                        * I(inherit): Use the inherited value.
+                                        * I(override): Use the value set in the object.
+                                        
+                                        Defaults to I(inherit).
+                                    type: str
+                                    returned: Always
+                                display_name:
+                                    description: >
+                                        The human-readable display name for the object referred to by I(source).
+                                    type: str
+                                    returned: Always
+                                source:
+                                    description: >
+                                        The resource identifier.
+                                    type: str
+                                    returned: Always
+                                value:
+                                    description: >
+                                        The inherited value.
+                                    type: list
+                                    returned: Always
+                                    elements: dict
+                                    contains:
+                                        type:
+                                            description: >
+                                                Type of ignore matching: client to ignore by client identifier (client hex or client text) or hardware to ignore by hardware identifier (MAC address). It can have one of the following values:
+                                                * I(client)hex_,
+                                                * I(client)text_,
+                                                * I(hardware).
+                                            type: str
+                                            returned: Always
+                                        value:
+                                            description: >
+                                                Value to match.
+                                            type: str
+                                            returned: Always
+                        lease_time:
+                            description: >
+                                The inheritance configuration for I(lease)timeI( field from )DHCPConfig_ object.
+                            type: dict
+                            returned: Always
+                            contains:
+                                action:
+                                    description: >
+                                        The inheritance setting for a field.
+                                        
+                                        Valid values are:
+                                        * I(inherit): Use the inherited value.
+                                        * I(override): Use the value set in the object.
+                                        
+                                        Defaults to I(inherit).
+                                    type: str
+                                    returned: Always
+                                display_name:
+                                    description: >
+                                        The human-readable display name for the object referred to by I(source).
+                                    type: str
+                                    returned: Always
+                                source:
+                                    description: >
+                                        The resource identifier.
+                                    type: str
+                                    returned: Always
+                                value:
+                                    description: >
+                                        The inherited value.
+                                    type: int
+                                    returned: Always
+                        lease_time_v6:
+                            description: >
+                                The inheritance configuration for I(lease)timeI(v6) field from I(DHCPConfig) object.
+                            type: dict
+                            returned: Always
+                            contains:
+                                action:
+                                    description: >
+                                        The inheritance setting for a field.
+                                        
+                                        Valid values are:
+                                        * I(inherit): Use the inherited value.
+                                        * I(override): Use the value set in the object.
+                                        
+                                        Defaults to I(inherit).
+                                    type: str
+                                    returned: Always
+                                display_name:
+                                    description: >
+                                        The human-readable display name for the object referred to by I(source).
+                                    type: str
+                                    returned: Always
+                                source:
+                                    description: >
+                                        The resource identifier.
+                                    type: str
+                                    returned: Always
+                                value:
+                                    description: >
+                                        The inherited value.
+                                    type: int
+                                    returned: Always
+                dhcp_options:
+                    description: >
+                        The inheritance configuration for I(dhcp)options_ field.
+                    type: dict
+                    returned: Always
+                    contains:
+                        action:
+                            description: >
+                                The inheritance setting.
+                                
+                                Valid values are:
+                                * I(inherit): Use the inherited value.
+                                * I(block): Don't use the inherited value.
+                                
+                                Defaults to I(inherit).
+                            type: str
+                            returned: Always
+                        value:
+                            description: >
+                                The inherited DHCP option values.
+                            type: list
+                            returned: Always
+                            elements: dict
+                            contains:
+                                action:
+                                    description: >
+                                        The inheritance setting.
+                                        
+                                        Valid values are:
+                                        * I(inherit): Use the inherited value.
+                                        * I(block): Don't use the inherited value.
+                                        
+                                        Defaults to I(inherit).
+                                    type: str
+                                    returned: Always
+                                display_name:
+                                    description: >
+                                        The human-readable display name for the object referred to by I(source).
+                                    type: str
+                                    returned: Always
+                                source:
+                                    description: >
+                                        The resource identifier.
+                                    type: str
+                                    returned: Always
+                                value:
+                                    description: >
+                                        The inherited value for the DHCP option.
+                                    type: dict
+                                    returned: Always
+                                    contains:
+                                        option:
+                                            description: >
+                                                Option inherited from the ancestor.
+                                            type: dict
+                                            returned: Always
+                                            contains:
+                                                group:
+                                                    description: >
+                                                        The resource identifier.
+                                                    type: str
+                                                    returned: Always
+                                                option_code:
+                                                    description: >
+                                                        The resource identifier.
+                                                    type: str
+                                                    returned: Always
+                                                option_value:
+                                                    description: >
+                                                        The option value.
+                                                    type: str
+                                                    returned: Always
+                                                type:
+                                                    description: >
+                                                        The type of item.
+                                                        
+                                                        Valid values are:
+                                                        * I(group)
+                                                        * I(option)
+                                                    type: str
+                                                    returned: Always
+                                        overriding_group:
+                                            description: >
+                                                The resource identifier.
+                                            type: str
+                                            returned: Always
+                dhcp_options_v6:
+                    description: >
+                        The inheritance configuration for I(dhcp)optionsI(v6) field.
+                    type: dict
+                    returned: Always
+                    contains:
+                        action:
+                            description: >
+                                The inheritance setting.
+                                
+                                Valid values are:
+                                * I(inherit): Use the inherited value.
+                                * I(block): Don't use the inherited value.
+                                
+                                Defaults to I(inherit).
+                            type: str
+                            returned: Always
+                        value:
+                            description: >
+                                The inherited DHCP option values.
+                            type: list
+                            returned: Always
+                            elements: dict
+                            contains:
+                                action:
+                                    description: >
+                                        The inheritance setting.
+                                        
+                                        Valid values are:
+                                        * I(inherit): Use the inherited value.
+                                        * I(block): Don't use the inherited value.
+                                        
+                                        Defaults to I(inherit).
+                                    type: str
+                                    returned: Always
+                                display_name:
+                                    description: >
+                                        The human-readable display name for the object referred to by I(source).
+                                    type: str
+                                    returned: Always
+                                source:
+                                    description: >
+                                        The resource identifier.
+                                    type: str
+                                    returned: Always
+                                value:
+                                    description: >
+                                        The inherited value for the DHCP option.
+                                    type: dict
+                                    returned: Always
+                                    contains:
+                                        option:
+                                            description: >
+                                                Option inherited from the ancestor.
+                                            type: dict
+                                            returned: Always
+                                            contains:
+                                                group:
+                                                    description: >
+                                                        The resource identifier.
+                                                    type: str
+                                                    returned: Always
+                                                option_code:
+                                                    description: >
+                                                        The resource identifier.
+                                                    type: str
+                                                    returned: Always
+                                                option_value:
+                                                    description: >
+                                                        The option value.
+                                                    type: str
+                                                    returned: Always
+                                                type:
+                                                    description: >
+                                                        The type of item.
+                                                        
+                                                        Valid values are:
+                                                        * I(group)
+                                                        * I(option)
+                                                    type: str
+                                                    returned: Always
+                                        overriding_group:
+                                            description: >
+                                                The resource identifier.
+                                            type: str
+                                            returned: Always
+                header_option_filename:
+                    description: >
+                        The inheritance configuration for I(header)optionI(filename) field.
+                    type: dict
+                    returned: Always
+                    contains:
+                        action:
+                            description: >
+                                The inheritance setting for a field.
+                                
+                                Valid values are:
+                                * I(inherit): Use the inherited value.
+                                * I(override): Use the value set in the object.
+                                
+                                Defaults to I(inherit).
+                            type: str
+                            returned: Always
+                        display_name:
+                            description: >
+                                The human-readable display name for the object referred to by I(source).
+                            type: str
+                            returned: Always
+                        source:
+                            description: >
+                                The resource identifier.
+                            type: str
+                            returned: Always
+                        value:
+                            description: >
+                                The inherited value.
+                            type: str
+                            returned: Always
+                header_option_server_address:
+                    description: >
+                        The inheritance configuration for I(header)optionI(server)address_ field.
+                    type: dict
+                    returned: Always
+                    contains:
+                        action:
+                            description: >
+                                The inheritance setting for a field.
+                                
+                                Valid values are:
+                                * I(inherit): Use the inherited value.
+                                * I(override): Use the value set in the object.
+                                
+                                Defaults to I(inherit).
+                            type: str
+                            returned: Always
+                        display_name:
+                            description: >
+                                The human-readable display name for the object referred to by I(source).
+                            type: str
+                            returned: Always
+                        source:
+                            description: >
+                                The resource identifier.
+                            type: str
+                            returned: Always
+                        value:
+                            description: >
+                                The inherited value.
+                            type: str
+                            returned: Always
+                header_option_server_name:
+                    description: >
+                        The inheritance configuration for I(header)optionI(server)name_ field.
+                    type: dict
+                    returned: Always
+                    contains:
+                        action:
+                            description: >
+                                The inheritance setting for a field.
+                                
+                                Valid values are:
+                                * I(inherit): Use the inherited value.
+                                * I(override): Use the value set in the object.
+                                
+                                Defaults to I(inherit).
+                            type: str
+                            returned: Always
+                        display_name:
+                            description: >
+                                The human-readable display name for the object referred to by I(source).
+                            type: str
+                            returned: Always
+                        source:
+                            description: >
+                                The resource identifier.
+                            type: str
+                            returned: Always
+                        value:
+                            description: >
+                                The inherited value.
+                            type: str
+                            returned: Always
+                hostname_rewrite_block:
+                    description: >
+                        The inheritance configuration for I(hostname)rewriteI(enabled), I(hostname)rewriteI(regex), and I(hostname)rewriteI(char) fields from I(IPSpace) object.
+                    type: dict
+                    returned: Always
+                    contains:
+                        action:
+                            description: >
+                                The inheritance setting.
+                                
+                                Valid values are:
+                                * I(inherit): Use the inherited value.
+                                * I(override): Use the value set in the object.
+                                
+                                Defaults to I(inherit).
+                            type: str
+                            returned: Always
+                        display_name:
+                            description: >
+                                The human-readable display name for the object referred to by I(source).
+                            type: str
+                            returned: Always
+                        source:
+                            description: >
+                                The resource identifier.
+                            type: str
+                            returned: Always
+                        value:
+                            description: >
+                                The inherited value.
+                            type: dict
+                            returned: Always
+                            contains:
+                                hostname_rewrite_char:
+                                    description: >
+                                        The inheritance configuration for I(hostname)rewriteI(char) field.
+                                    type: str
+                                    returned: Always
+                                hostname_rewrite_enabled:
+                                    description: >
+                                        The inheritance configuration for I(hostname)rewriteI(enabled) field.
+                                    type: bool
+                                    returned: Always
+                                hostname_rewrite_regex:
+                                    description: >
+                                        The inheritance configuration for I(hostname)rewriteI(regex) field.
+                                    type: str
+                                    returned: Always
+                vendor_specific_option_option_space:
+                    description: >
+                        The inheritance configuration for I(vendor)specificI(option)optionI(space) field.
+                    type: dict
+                    returned: Always
+                    contains:
+                        action:
+                            description: >
+                                The inheritance setting for a field.
+                                
+                                Valid values are:
+                                * I(inherit): Use the inherited value.
+                                * I(override): Use the value set in the object.
+                                
+                                Defaults to I(inherit).
+                            type: str
+                            returned: Always
+                        display_name:
+                            description: >
+                                The human-readable display name for the object referred to by I(source).
+                            type: str
+                            returned: Always
+                        source:
+                            description: >
+                                The resource identifier.
+                            type: str
+                            returned: Always
+                        value:
+                            description: >
+                                The resource identifier.
+                            type: str
+                            returned: Always
+        name:
+            description: >
+                The name of the IP space. Must contain 1 to 256 characters. Can include UTF-8.
+            type: str
+            returned: Always
+        tags:
+            description: >
+                The tags for the IP space in JSON format.
+            type: dict
+            returned: Always
+        threshold:
+            description: >
+                The utilization threshold settings for the IP space.
+            type: dict
+            returned: Always
+            contains:
+                enabled:
+                    description: >
+                        Indicates whether the utilization threshold for IP addresses is enabled or not.
+                    type: bool
+                    returned: Always
+                high:
+                    description: >
+                        The high threshold value for the percentage of used IP addresses relative to the total IP addresses available in the scope of the object. Thresholds are inclusive in the comparison test.
+                    type: int
+                    returned: Always
+                low:
+                    description: >
+                        The low threshold value for the percentage of used IP addresses relative to the total IP addresses available in the scope of the object. Thresholds are inclusive in the comparison test.
+                    type: int
+                    returned: Always
+        updated_at:
+            description: >
+                Time when the object has been updated. Equals to I(created)at_ if not updated after creation.
+            type: str
+            returned: Always
+        utilization:
+            description: >
+                The utilization of IPV4 addresses in the IP space.
+            type: dict
+            returned: Always
+            contains:
+                abandon_utilization:
+                    description: >
+                        The percentage of abandoned IP addresses relative to the total IP addresses available in the scope of the object.
+                    type: int
+                    returned: Always
+                abandoned:
+                    description: >
+                        The number of IP addresses in the scope of the object which are in the abandoned state (issued by a DHCP server and then declined by the client).
+                    type: str
+                    returned: Always
+                dynamic:
+                    description: >
+                        The number of IP addresses handed out by DHCP in the scope of the object. This includes all leased addresses, fixed addresses that are defined but not currently leased and abandoned leases.
+                    type: str
+                    returned: Always
+                free:
+                    description: >
+                        The number of IP addresses available in the scope of the object.
+                    type: str
+                    returned: Always
+                static:
+                    description: >
+                        The number of defined IP addresses such as reservations or DNS records. It can be computed as I(static) = I(used) - I(dynamic).
+                    type: str
+                    returned: Always
+                total:
+                    description: >
+                        The total number of IP addresses available in the scope of the object.
+                    type: str
+                    returned: Always
+                used:
+                    description: >
+                        The number of IP addresses used in the scope of the object.
+                    type: str
+                    returned: Always
+                utilization:
+                    description: >
+                        The percentage of used IP addresses relative to the total IP addresses available in the scope of the object.
+                    type: int
+                    returned: Always
+        utilization_v6:
+            description: >
+                The utilization of IPV6 addresses in the IP space.
+            type: dict
+            returned: Always
+            contains:
+                abandoned:
+                    description: ""
+                    type: str
+                    returned: Always
+                dynamic:
+                    description: ""
+                    type: str
+                    returned: Always
+                static:
+                    description: ""
+                    type: str
+                    returned: Always
+                total:
+                    description: ""
+                    type: str
+                    returned: Always
+                used:
+                    description: ""
+                    type: str
+                    returned: Always
+        vendor_specific_option_option_space:
+            description: >
+                The resource identifier.
+            type: str
+            returned: Always
+"""  # noqa: E501
+
+from ansible_collections.infoblox.bloxone.plugins.module_utils.modules import BloxoneAnsibleModule
+
+try:
+    from bloxone_client import ApiException, NotFoundException
+    from ipam import IPSpace, IpSpaceApi
+except ImportError:
+    pass  # Handled by BloxoneAnsibleModule
+
+
+class IpSpaceModule(BloxoneAnsibleModule):
+    def __init__(self, *args, **kwargs):
+        super(IpSpaceModule, self).__init__(*args, **kwargs)
+
+        exclude = ["state", "csp_url", "api_key", "id"]
+        self._payload_params = {k: v for k, v in self.params.items() if v is not None and k not in exclude}
+        self._payload = IPSpace.from_dict(self._payload_params)
+        self._existing = None
+
+    @property
+    def existing(self):
+        return self._existing
+
+    @existing.setter
+    def existing(self, value):
+        self._existing = value
+
+    @property
+    def payload_params(self):
+        return self._payload_params
+
+    @property
+    def payload(self):
+        return self._payload
+
+    def payload_changed(self):
+        if self.existing is None:
+            # if existing is None, then it is a create operation
+            return True
+
+        return self.is_changed(self.existing.model_dump(by_alias=True, exclude_none=True), self.payload_params)
+
+    def find(self):
+        if self.params["id"] is not None:
+            try:
+                resp = IpSpaceApi(self.client).read(self.params["id"], inherit="full")
+                return resp.result
+            except NotFoundException as e:
+                if self.params["state"] == "absent":
+                    return None
+                raise e
+        else:
+            filter = f"name=='{self.params['name']}'"
+            resp = IpSpaceApi(self.client).list(filter=filter, inherit="full")
+            if len(resp.results) == 1:
+                return resp.results[0]
+            if len(resp.results) > 1:
+                self.fail_json(msg=f"Found multiple IpSpace: {resp.results}")
+            if len(resp.results) == 0:
+                return None
+
+    def create(self):
+        if self.check_mode:
+            return None
+
+        resp = IpSpaceApi(self.client).create(body=self.payload, inherit="full")
+        return resp.result.model_dump(by_alias=True, exclude_none=True)
+
+    def update(self):
+        if self.check_mode:
+            return None
+
+        resp = IpSpaceApi(self.client).update(id=self.existing.id, body=self.payload, inherit="full")
+        return resp.result.model_dump(by_alias=True, exclude_none=True)
+
+    def delete(self):
+        if self.check_mode:
+            return
+
+        IpSpaceApi(self.client).delete(self.existing.id)
+
+    def run_command(self):
+        result = dict(changed=False, item={}, id=None)
+
+        # based on the state that is passed in, we will execute the appropriate
+        # functions
+        try:
+            self.existing = self.find()
+            item = {}
+            if self.params["state"] == "present" and self.existing is None:
+                item = self.create()
+                result["changed"] = True
+                result["msg"] = "IpSpace created"
+            elif self.params["state"] == "present" and self.existing is not None:
+                if self.payload_changed():
+                    item = self.update()
+                    result["changed"] = True
+                    result["msg"] = "IpSpace updated"
+            elif self.params["state"] == "absent" and self.existing is not None:
+                self.delete()
+                result["changed"] = True
+                result["msg"] = "IpSpace deleted"
+
+            if self.check_mode:
+                # if in check mode, do not update the result or the diff, just return the changed state
+                self.exit_json(**result)
+
+            result["diff"] = dict(
+                before=self.existing.model_dump(by_alias=True, exclude_none=True) if self.existing is not None else {},
+                after=item,
+            )
+            result["item"] = item
+            result["id"] = (
+                self.existing.id if self.existing is not None else item["id"] if (item and "id" in item) else None
+            )
+        except ApiException as e:
+            self.fail_json(msg=f"Failed to execute command: {e.status} {e.reason} {e.body}")
+
+        self.exit_json(**result)
+
+
+def main():
+    object_args = dict(
+        asm_config=dict(
+            type="dict",
+            options=dict(
+                asm_threshold=dict(type="int"),
+                enable=dict(type="bool"),
+                enable_notification=dict(type="bool"),
+                forecast_period=dict(type="int"),
+                growth_factor=dict(type="int"),
+                growth_type=dict(type="str"),
+                history=dict(type="int"),
+                min_total=dict(type="int"),
+                min_unused=dict(type="int"),
+                reenable_date=dict(type="str"),
+            ),
+        ),
+        comment=dict(type="str"),
+        ddns_client_update=dict(type="str"),
+        ddns_conflict_resolution_mode=dict(type="str"),
+        ddns_domain=dict(type="str"),
+        ddns_generate_name=dict(type="bool"),
+        ddns_generated_prefix=dict(type="str"),
+        ddns_send_updates=dict(type="bool"),
+        ddns_ttl_percent=dict(type="float"),
+        ddns_update_on_renew=dict(type="bool"),
+        ddns_use_conflict_resolution=dict(type="bool"),
+        dhcp_config=dict(
+            type="dict",
+            options=dict(
+                abandoned_reclaim_time=dict(type="int"),
+                abandoned_reclaim_time_v6=dict(type="int"),
+                allow_unknown=dict(type="bool"),
+                allow_unknown_v6=dict(type="bool"),
+                echo_client_id=dict(type="bool"),
+                filters=dict(type="list", elements="str"),
+                filters_v6=dict(type="list", elements="str"),
+                ignore_client_uid=dict(type="bool"),
+                ignore_list=dict(
+                    type="list",
+                    elements="dict",
+                    options=dict(
+                        type=dict(type="str"),
+                        value=dict(type="str"),
+                    ),
+                ),
+                lease_time=dict(type="int"),
+                lease_time_v6=dict(type="int"),
+            ),
+        ),
+        dhcp_options=dict(
+            type="list",
+            elements="dict",
+            options=dict(
+                group=dict(type="str"),
+                option_code=dict(type="str"),
+                option_value=dict(type="str"),
+                type=dict(type="str"),
+            ),
+        ),
+        dhcp_options_v6=dict(
+            type="list",
+            elements="dict",
+            options=dict(
+                group=dict(type="str"),
+                option_code=dict(type="str"),
+                option_value=dict(type="str"),
+                type=dict(type="str"),
+            ),
+        ),
+        header_option_filename=dict(type="str"),
+        header_option_server_address=dict(type="str"),
+        header_option_server_name=dict(type="str"),
+        hostname_rewrite_char=dict(type="str"),
+        hostname_rewrite_enabled=dict(type="bool"),
+        hostname_rewrite_regex=dict(type="str"),
+        inheritance_sources=dict(
+            type="dict",
+            options=dict(
+                asm_config=dict(
+                    type="dict",
+                    options=dict(
+                        asm_enable_block=dict(
+                            type="dict",
+                            options=dict(
+                                action=dict(type="str"),
+                            ),
+                        ),
+                        asm_growth_block=dict(
+                            type="dict",
+                            options=dict(
+                                action=dict(type="str"),
+                            ),
+                        ),
+                        asm_threshold=dict(
+                            type="dict",
+                            options=dict(
+                                action=dict(type="str"),
+                            ),
+                        ),
+                        forecast_period=dict(
+                            type="dict",
+                            options=dict(
+                                action=dict(type="str"),
+                            ),
+                        ),
+                        history=dict(
+                            type="dict",
+                            options=dict(
+                                action=dict(type="str"),
+                            ),
+                        ),
+                        min_total=dict(
+                            type="dict",
+                            options=dict(
+                                action=dict(type="str"),
+                            ),
+                        ),
+                        min_unused=dict(
+                            type="dict",
+                            options=dict(
+                                action=dict(type="str"),
+                            ),
+                        ),
+                    ),
+                ),
+                ddns_client_update=dict(
+                    type="dict",
+                    options=dict(
+                        action=dict(type="str"),
+                    ),
+                ),
+                ddns_conflict_resolution_mode=dict(
+                    type="dict",
+                    options=dict(
+                        action=dict(type="str"),
+                    ),
+                ),
+                ddns_enabled=dict(
+                    type="dict",
+                    options=dict(
+                        action=dict(type="str"),
+                    ),
+                ),
+                ddns_hostname_block=dict(
+                    type="dict",
+                    options=dict(
+                        action=dict(type="str"),
+                    ),
+                ),
+                ddns_ttl_percent=dict(
+                    type="dict",
+                    options=dict(
+                        action=dict(type="str"),
+                    ),
+                ),
+                ddns_update_block=dict(
+                    type="dict",
+                    options=dict(
+                        action=dict(type="str"),
+                    ),
+                ),
+                ddns_update_on_renew=dict(
+                    type="dict",
+                    options=dict(
+                        action=dict(type="str"),
+                    ),
+                ),
+                ddns_use_conflict_resolution=dict(
+                    type="dict",
+                    options=dict(
+                        action=dict(type="str"),
+                    ),
+                ),
+                dhcp_config=dict(
+                    type="dict",
+                    options=dict(
+                        abandoned_reclaim_time=dict(
+                            type="dict",
+                            options=dict(
+                                action=dict(type="str"),
+                            ),
+                        ),
+                        abandoned_reclaim_time_v6=dict(
+                            type="dict",
+                            options=dict(
+                                action=dict(type="str"),
+                            ),
+                        ),
+                        allow_unknown=dict(
+                            type="dict",
+                            options=dict(
+                                action=dict(type="str"),
+                            ),
+                        ),
+                        allow_unknown_v6=dict(
+                            type="dict",
+                            options=dict(
+                                action=dict(type="str"),
+                            ),
+                        ),
+                        echo_client_id=dict(
+                            type="dict",
+                            options=dict(
+                                action=dict(type="str"),
+                            ),
+                        ),
+                        filters=dict(
+                            type="dict",
+                            options=dict(
+                                action=dict(type="str"),
+                                value=dict(type="list", elements="str"),
+                            ),
+                        ),
+                        filters_v6=dict(
+                            type="dict",
+                            options=dict(
+                                action=dict(type="str"),
+                                value=dict(type="list", elements="str"),
+                            ),
+                        ),
+                        ignore_client_uid=dict(
+                            type="dict",
+                            options=dict(
+                                action=dict(type="str"),
+                            ),
+                        ),
+                        ignore_list=dict(
+                            type="dict",
+                            options=dict(
+                                action=dict(type="str"),
+                            ),
+                        ),
+                        lease_time=dict(
+                            type="dict",
+                            options=dict(
+                                action=dict(type="str"),
+                            ),
+                        ),
+                        lease_time_v6=dict(
+                            type="dict",
+                            options=dict(
+                                action=dict(type="str"),
+                            ),
+                        ),
+                    ),
+                ),
+                dhcp_options=dict(
+                    type="dict",
+                    options=dict(
+                        action=dict(type="str"),
+                        value=dict(
+                            type="list",
+                            elements="dict",
+                            options=dict(
+                                action=dict(type="str"),
+                            ),
+                        ),
+                    ),
+                ),
+                dhcp_options_v6=dict(
+                    type="dict",
+                    options=dict(
+                        action=dict(type="str"),
+                        value=dict(
+                            type="list",
+                            elements="dict",
+                            options=dict(
+                                action=dict(type="str"),
+                            ),
+                        ),
+                    ),
+                ),
+                header_option_filename=dict(
+                    type="dict",
+                    options=dict(
+                        action=dict(type="str"),
+                    ),
+                ),
+                header_option_server_address=dict(
+                    type="dict",
+                    options=dict(
+                        action=dict(type="str"),
+                    ),
+                ),
+                header_option_server_name=dict(
+                    type="dict",
+                    options=dict(
+                        action=dict(type="str"),
+                    ),
+                ),
+                hostname_rewrite_block=dict(
+                    type="dict",
+                    options=dict(
+                        action=dict(type="str"),
+                    ),
+                ),
+                vendor_specific_option_option_space=dict(
+                    type="dict",
+                    options=dict(
+                        action=dict(type="str"),
+                        value=dict(type="str"),
+                    ),
+                ),
+            ),
+        ),
+        name=dict(type="str"),
+        tags=dict(type="dict"),
+        vendor_specific_option_option_space=dict(type="str"),
+    )
+
+    module_args = dict(
+        id=dict(type="str", required=False),
+        state=dict(type="str", required=False, choices=["present", "absent"], default="present"),
+    )
+    module_args.update(object_args)
+
+    module = IpSpaceModule(
+        argument_spec=module_args,
+        supports_check_mode=True,
+        required_if=[("state", "present", ["name"])],
+    )
+
+    module.run_command()
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/ipam_ip_space_info.py
+++ b/plugins/modules/ipam_ip_space_info.py
@@ -82,7 +82,7 @@ id:
         - ID of the IpSpace object
     type: str
     returned: Always
-results:
+objects:
     description:
         - IpSpace object
     type: list
@@ -1844,7 +1844,7 @@ class IpSpaceInfoModule(BloxoneAnsibleModule):
         while True:
             try:
                 resp = IpSpaceApi(self.client).list(
-                    filter=filter_str, tfilter=tag_filter_str, inherit="full", offset=offset, limit=self._limit
+                    offset=offset, limit=self._limit, filter=filter_str, tfilter=tag_filter_str, inherit="full"
                 )
                 all_results.extend(resp.results)
 
@@ -1855,11 +1855,10 @@ class IpSpaceInfoModule(BloxoneAnsibleModule):
             except ApiException as e:
                 self.fail_json(msg=f"Failed to execute command: {e.status} {e.reason} {e.body}")
 
-        resp = IpSpaceApi(self.client).list(filter=filter_str, tfilter=tag_filter_str, inherit="full")
-        return resp.results
+        return all_results
 
     def run_command(self):
-        result = dict(results=[])
+        result = dict(objects=[])
 
         if self.check_mode:
             self.exit_json(**result)
@@ -1870,7 +1869,7 @@ class IpSpaceInfoModule(BloxoneAnsibleModule):
         for r in find_results:
             all_results.append(r.model_dump(by_alias=True, exclude_none=True))
 
-        result["results"] = all_results
+        result["objects"] = all_results
         self.exit_json(**result)
 
 

--- a/plugins/modules/ipam_ip_space_info.py
+++ b/plugins/modules/ipam_ip_space_info.py
@@ -1,0 +1,1900 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: Infoblox Inc.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ipam_ip_space_info
+short_description: Manage IpSpace
+description:
+    - Manage IpSpace
+version_added: 2.0.0
+author: Infoblox Inc. (@infobloxopen)
+options:
+    id:
+        description:
+            - ID of the object
+        type: str
+        required: false
+    filters:
+        description:
+            - Filter dict to filter objects
+        type: dict
+        required: false
+    filter_query:
+        description:
+            - Filter query to filter objects
+        type: str
+        required: false
+    inherit:
+        description:
+            - Return inheritance information
+        type: str
+        required: false
+        choices:
+            - full
+            - partial
+            - none
+        default: full
+    tag_filters:
+        description:
+            - Filter dict to filter objects by tags
+        type: dict
+        required: false
+    tag_filter_query:
+        description:
+            - Filter query to filter objects by tags
+        type: str
+        required: false
+
+extends_documentation_fragment:
+    - infoblox.bloxone.common
+"""  # noqa: E501
+
+EXAMPLES = r"""
+  - name: Get IP Space information by ID
+    infoblox.bloxone.ipam_ip_space_info:
+      id: "{{ ip_space_id }}"
+
+  - name: Get IP Space information by filters (e.g. name)
+    infoblox.bloxone.ipam_ip_space_info:
+      filters:
+        name: "my-ip-space"
+
+  - name: Get IP Space information by raw filter query
+    infoblox.bloxone.ipam_ip_space_info:
+      filter_query: "name=='my-ip-space'"
+
+  - name: Get IP Space information by tag filters
+    infoblox.bloxone.ipam_ip_space_info:
+      tag_filters:
+        location: "site-1"
+"""  # noqa: E501
+
+RETURN = r"""
+id:
+    description:
+        - ID of the IpSpace object
+    type: str
+    returned: Always
+results:
+    description:
+        - IpSpace object
+    type: list
+    elements: dict
+    returned: Always
+    contains:
+        asm_config:
+            description: >
+                The Automated Scope Management configuration for the IP space.
+            type: dict
+            returned: Always
+            contains:
+                asm_threshold:
+                    description: >
+                        ASM shows the number of addresses forecast to be used I(forecast)periodI( days in the future, if it is greater than )asmI(threshold) percent * I(dhcp)totalI( (see )dhcpI(utilization)) then the subnet is flagged.
+                    type: int
+                    returned: Always
+                enable:
+                    description: >
+                        Indicates if Automated Scope Management is enabled.
+                    type: bool
+                    returned: Always
+                enable_notification:
+                    description: >
+                        Indicates if ASM should send notifications to the user.
+                    type: bool
+                    returned: Always
+                forecast_period:
+                    description: >
+                        The forecast period in days.
+                    type: int
+                    returned: Always
+                growth_factor:
+                    description: >
+                        Indicates the growth in the number or percentage of IP addresses.
+                    type: int
+                    returned: Always
+                growth_type:
+                    description: >
+                        The type of factor to use: I(percent) or I(count).
+                    type: str
+                    returned: Always
+                history:
+                    description: >
+                        The minimum amount of history needed before ASM can run on this subnet.
+                    type: int
+                    returned: Always
+                min_total:
+                    description: >
+                        The minimum size of range needed for ASM to run on this subnet.
+                    type: int
+                    returned: Always
+                min_unused:
+                    description: >
+                        The minimum percentage of addresses that must be available outside of the DHCP ranges and fixed addresses
+                        when making a suggested change..
+                    type: int
+                    returned: Always
+                reenable_date:
+                    description: ""
+                    type: str
+                    returned: Always
+        asm_scope_flag:
+            description: >
+                The number of times the automated scope management usage limits have been exceeded for any of the subnets in this IP space.
+            type: int
+            returned: Always
+        comment:
+            description: >
+                The description for the IP space. May contain 0 to 1024 characters. Can include UTF-8.
+            type: str
+            returned: Always
+        created_at:
+            description: >
+                Time when the object has been created.
+            type: str
+            returned: Always
+        ddns_client_update:
+            description: >
+                Controls who does the DDNS updates.
+                
+                Valid values are:
+                * I(client): DHCP server updates DNS if requested by client.
+                * I(server): DHCP server always updates DNS, overriding an update request from the client, unless the client requests no updates.
+                * I(ignore): DHCP server always updates DNS, even if the client says not to.
+                * I(over)clientI(update): Same as I(server). DHCP server always updates DNS, overriding an update request from the client, unless the client requests no updates.
+                * I(over)noI(update): DHCP server updates DNS even if the client requests that no updates be done. If the client requests to do the update, DHCP server allows it.
+                
+                Defaults to I(client).
+            type: str
+            returned: Always
+        ddns_conflict_resolution_mode:
+            description: >
+                The mode used for resolving conflicts while performing DDNS updates.
+                
+                Valid values are:
+                * I(check)withI(dhcid): It includes adding a DHCID record and checking that record via conflict detection as per RFC 4703.
+                * I(no)checkI(with)dhcid_: This will ignore conflict detection but add a DHCID record when creating/updating an entry.
+                * I(check)existsI(with)dhcid_: This will check if there is an existing DHCID record but does not verify the value of the record matches the update. This will also update the DHCID record for the entry.
+                * I(no)checkI(without)dhcid_: This ignores conflict detection and will not add a DHCID record when creating/updating a DDNS entry.
+                
+                Defaults to I(check)withI(dhcid).
+            type: str
+            returned: Always
+        ddns_domain:
+            description: >
+                The domain suffix for DDNS updates. FQDN, may be empty.
+                
+                Defaults to empty.
+            type: str
+            returned: Always
+        ddns_generate_name:
+            description: >
+                Indicates if DDNS needs to generate a hostname when not supplied by the client.
+                
+                Defaults to I(false).
+            type: bool
+            returned: Always
+        ddns_generated_prefix:
+            description: >
+                The prefix used in the generation of an FQDN.
+                
+                When generating a name, DHCP server will construct the name in the format: [ddns-generated-prefix]-[address-text].[ddns-qualifying-suffix].
+                where address-text is simply the lease IP address converted to a hyphenated string.
+                
+                Defaults to "myhost".
+            type: str
+            returned: Always
+        ddns_send_updates:
+            description: >
+                Determines if DDNS updates are enabled at the IP space level.
+                Defaults to I(true).
+            type: bool
+            returned: Always
+        ddns_ttl_percent:
+            description: >
+                DDNS TTL value - to be calculated as a simple percentage of the lease's lifetime, using the parameter's value as the percentage.
+                It is specified as a percentage (e.g. 25, 75).
+                Defaults to unspecified.
+            type: float
+            returned: Always
+        ddns_update_on_renew:
+            description: >
+                Instructs the DHCP server to always update the DNS information when a lease is renewed even if its DNS information has not changed.
+                
+                Defaults to I(false).
+            type: bool
+            returned: Always
+        ddns_use_conflict_resolution:
+            description: >
+                When true, DHCP server will apply conflict resolution, as described in RFC 4703, when attempting to fulfill the update request.
+                
+                When false, DHCP server will simply attempt to update the DNS entries per the request, regardless of whether or not they conflict with existing entries owned by other DHCP4 clients.
+                
+                Defaults to I(true).
+            type: bool
+            returned: Always
+        dhcp_config:
+            description: >
+                The shared DHCP configuration for the IP space that controls how leases are issued.
+            type: dict
+            returned: Always
+            contains:
+                abandoned_reclaim_time:
+                    description: >
+                        The abandoned reclaim time in seconds for IPV4 clients.
+                    type: int
+                    returned: Always
+                abandoned_reclaim_time_v6:
+                    description: >
+                        The abandoned reclaim time in seconds for IPV6 clients.
+                    type: int
+                    returned: Always
+                allow_unknown:
+                    description: >
+                        Disable to allow leases only for known IPv4 clients, those for which a fixed address is configured.
+                    type: bool
+                    returned: Always
+                allow_unknown_v6:
+                    description: >
+                        Disable to allow leases only for known IPV6 clients, those for which a fixed address is configured.
+                    type: bool
+                    returned: Always
+                echo_client_id:
+                    description: >
+                        Enable/disable to include/exclude the client id when responding to discover or request.
+                    type: bool
+                    returned: Always
+                filters:
+                    description: >
+                        The resource identifier.
+                    type: list
+                    returned: Always
+                filters_v6:
+                    description: >
+                        The resource identifier.
+                    type: list
+                    returned: Always
+                ignore_client_uid:
+                    description: >
+                        Enable to ignore the client UID when issuing a DHCP lease. Use this option to prevent assigning two IP addresses for a client which does not have a UID during one phase of PXE boot but acquires one for the other phase.
+                    type: bool
+                    returned: Always
+                ignore_list:
+                    description: >
+                        The list of clients to ignore requests from.
+                    type: list
+                    returned: Always
+                    elements: dict
+                    contains:
+                        type:
+                            description: >
+                                Type of ignore matching: client to ignore by client identifier (client hex or client text) or hardware to ignore by hardware identifier (MAC address). It can have one of the following values:
+                                * I(client)hex_,
+                                * I(client)text_,
+                                * I(hardware).
+                            type: str
+                            returned: Always
+                        value:
+                            description: >
+                                Value to match.
+                            type: str
+                            returned: Always
+                lease_time:
+                    description: >
+                        The lease duration in seconds.
+                    type: int
+                    returned: Always
+                lease_time_v6:
+                    description: >
+                        The lease duration in seconds for IPV6 clients.
+                    type: int
+                    returned: Always
+        dhcp_options:
+            description: >
+                The list of IPv4 DHCP options for IP space. May be either a specific option or a group of options.
+            type: list
+            returned: Always
+            elements: dict
+            contains:
+                group:
+                    description: >
+                        The resource identifier.
+                    type: str
+                    returned: Always
+                option_code:
+                    description: >
+                        The resource identifier.
+                    type: str
+                    returned: Always
+                option_value:
+                    description: >
+                        The option value.
+                    type: str
+                    returned: Always
+                type:
+                    description: >
+                        The type of item.
+                        
+                        Valid values are:
+                        * I(group)
+                        * I(option)
+                    type: str
+                    returned: Always
+        dhcp_options_v6:
+            description: >
+                The list of IPv6 DHCP options for IP space. May be either a specific option or a group of options.
+            type: list
+            returned: Always
+            elements: dict
+            contains:
+                group:
+                    description: >
+                        The resource identifier.
+                    type: str
+                    returned: Always
+                option_code:
+                    description: >
+                        The resource identifier.
+                    type: str
+                    returned: Always
+                option_value:
+                    description: >
+                        The option value.
+                    type: str
+                    returned: Always
+                type:
+                    description: >
+                        The type of item.
+                        
+                        Valid values are:
+                        * I(group)
+                        * I(option)
+                    type: str
+                    returned: Always
+        header_option_filename:
+            description: >
+                The configuration for header option filename field.
+            type: str
+            returned: Always
+        header_option_server_address:
+            description: >
+                The configuration for header option server address field.
+            type: str
+            returned: Always
+        header_option_server_name:
+            description: >
+                The configuration for header option server name field.
+            type: str
+            returned: Always
+        hostname_rewrite_char:
+            description: >
+                The character to replace non-matching characters with, when hostname rewrite is enabled.
+                
+                Any single ASCII character or no character if the invalid characters should be removed without replacement.
+                
+                Defaults to "-".
+            type: str
+            returned: Always
+        hostname_rewrite_enabled:
+            description: >
+                Indicates if client supplied hostnames will be rewritten prior to DDNS update by replacing every character that does not match I(hostname)rewriteI(regex) by I(hostname)rewriteI(char).
+                
+                Defaults to I(false).
+            type: bool
+            returned: Always
+        hostname_rewrite_regex:
+            description: >
+                The regex bracket expression to match valid characters.
+                
+                Must begin with "[" and end with "]" and be a compilable POSIX regex.
+                
+                Defaults to "[^a-zA-Z0-9_.]".
+            type: str
+            returned: Always
+        id:
+            description: >
+                The resource identifier.
+            type: str
+            returned: Always
+        inheritance_sources:
+            description: >
+                The inheritance configuration.
+            type: dict
+            returned: Always
+            contains:
+                asm_config:
+                    description: >
+                        The inheritance configuration for I(asm)config_ field.
+                    type: dict
+                    returned: Always
+                    contains:
+                        asm_enable_block:
+                            description: >
+                                The block of ASM fields: I(enable), I(enable)notificationI(, )reenableI(date).
+                            type: dict
+                            returned: Always
+                            contains:
+                                action:
+                                    description: >
+                                        The inheritance setting.
+                                        
+                                        Valid values are:
+                                        * I(inherit): Use the inherited value.
+                                        * I(override): Use the value set in the object.
+                                        
+                                        Defaults to I(inherit).
+                                    type: str
+                                    returned: Always
+                                display_name:
+                                    description: >
+                                        The human-readable display name for the object referred to by I(source).
+                                    type: str
+                                    returned: Always
+                                source:
+                                    description: >
+                                        The resource identifier.
+                                    type: str
+                                    returned: Always
+                                value:
+                                    description: >
+                                        The inherited value.
+                                    type: dict
+                                    returned: Always
+                                    contains:
+                                        enable:
+                                            description: >
+                                                Indicates whether Automated Scope Management is enabled or not.
+                                            type: bool
+                                            returned: Always
+                                        enable_notification:
+                                            description: >
+                                                Indicates whether sending notifications to the users is enabled or not.
+                                            type: bool
+                                            returned: Always
+                                        reenable_date:
+                                            description: >
+                                                The date at which notifications will be re-enabled automatically.
+                                            type: str
+                                            returned: Always
+                        asm_growth_block:
+                            description: >
+                                The block of ASM fields: I(growth)factorI(, )growthI(type).
+                            type: dict
+                            returned: Always
+                            contains:
+                                action:
+                                    description: >
+                                        The inheritance setting.
+                                        
+                                        Valid values are:
+                                        * I(inherit): Use the inherited value.
+                                        * I(override): Use the value set in the object.
+                                        
+                                        Defaults to I(inherit).
+                                    type: str
+                                    returned: Always
+                                display_name:
+                                    description: >
+                                        The human-readable display name for the object referred to by I(source).
+                                    type: str
+                                    returned: Always
+                                source:
+                                    description: >
+                                        The resource identifier.
+                                    type: str
+                                    returned: Always
+                                value:
+                                    description: >
+                                        The inherited value.
+                                    type: dict
+                                    returned: Always
+                                    contains:
+                                        growth_factor:
+                                            description: >
+                                                Either the number or percentage of addresses to grow by.
+                                            type: int
+                                            returned: Always
+                                        growth_type:
+                                            description: >
+                                                The type of factor to use: I(percent) or I(count).
+                                            type: str
+                                            returned: Always
+                        asm_threshold:
+                            description: >
+                                ASM shows the number of addresses forecast to be used I(forecast)periodI( days in the future, if it is greater than )asmI(threshold)percentI( * )dhcpI(total) (see I(dhcp)utilization_) then the subnet is flagged.
+                            type: dict
+                            returned: Always
+                            contains:
+                                action:
+                                    description: >
+                                        The inheritance setting for a field.
+                                        
+                                        Valid values are:
+                                        * I(inherit): Use the inherited value.
+                                        * I(override): Use the value set in the object.
+                                        
+                                        Defaults to I(inherit).
+                                    type: str
+                                    returned: Always
+                                display_name:
+                                    description: >
+                                        The human-readable display name for the object referred to by I(source).
+                                    type: str
+                                    returned: Always
+                                source:
+                                    description: >
+                                        The resource identifier.
+                                    type: str
+                                    returned: Always
+                                value:
+                                    description: >
+                                        The inherited value.
+                                    type: int
+                                    returned: Always
+                        forecast_period:
+                            description: >
+                                The forecast period in days.
+                            type: dict
+                            returned: Always
+                            contains:
+                                action:
+                                    description: >
+                                        The inheritance setting for a field.
+                                        
+                                        Valid values are:
+                                        * I(inherit): Use the inherited value.
+                                        * I(override): Use the value set in the object.
+                                        
+                                        Defaults to I(inherit).
+                                    type: str
+                                    returned: Always
+                                display_name:
+                                    description: >
+                                        The human-readable display name for the object referred to by I(source).
+                                    type: str
+                                    returned: Always
+                                source:
+                                    description: >
+                                        The resource identifier.
+                                    type: str
+                                    returned: Always
+                                value:
+                                    description: >
+                                        The inherited value.
+                                    type: int
+                                    returned: Always
+                        history:
+                            description: >
+                                The minimum amount of history needed before ASM can run on this subnet.
+                            type: dict
+                            returned: Always
+                            contains:
+                                action:
+                                    description: >
+                                        The inheritance setting for a field.
+                                        
+                                        Valid values are:
+                                        * I(inherit): Use the inherited value.
+                                        * I(override): Use the value set in the object.
+                                        
+                                        Defaults to I(inherit).
+                                    type: str
+                                    returned: Always
+                                display_name:
+                                    description: >
+                                        The human-readable display name for the object referred to by I(source).
+                                    type: str
+                                    returned: Always
+                                source:
+                                    description: >
+                                        The resource identifier.
+                                    type: str
+                                    returned: Always
+                                value:
+                                    description: >
+                                        The inherited value.
+                                    type: int
+                                    returned: Always
+                        min_total:
+                            description: >
+                                The minimum size of range needed for ASM to run on this subnet.
+                            type: dict
+                            returned: Always
+                            contains:
+                                action:
+                                    description: >
+                                        The inheritance setting for a field.
+                                        
+                                        Valid values are:
+                                        * I(inherit): Use the inherited value.
+                                        * I(override): Use the value set in the object.
+                                        
+                                        Defaults to I(inherit).
+                                    type: str
+                                    returned: Always
+                                display_name:
+                                    description: >
+                                        The human-readable display name for the object referred to by I(source).
+                                    type: str
+                                    returned: Always
+                                source:
+                                    description: >
+                                        The resource identifier.
+                                    type: str
+                                    returned: Always
+                                value:
+                                    description: >
+                                        The inherited value.
+                                    type: int
+                                    returned: Always
+                        min_unused:
+                            description: >
+                                The minimum percentage of addresses that must be available outside of the DHCP ranges and fixed addresses when making a suggested change.
+                            type: dict
+                            returned: Always
+                            contains:
+                                action:
+                                    description: >
+                                        The inheritance setting for a field.
+                                        
+                                        Valid values are:
+                                        * I(inherit): Use the inherited value.
+                                        * I(override): Use the value set in the object.
+                                        
+                                        Defaults to I(inherit).
+                                    type: str
+                                    returned: Always
+                                display_name:
+                                    description: >
+                                        The human-readable display name for the object referred to by I(source).
+                                    type: str
+                                    returned: Always
+                                source:
+                                    description: >
+                                        The resource identifier.
+                                    type: str
+                                    returned: Always
+                                value:
+                                    description: >
+                                        The inherited value.
+                                    type: int
+                                    returned: Always
+                ddns_client_update:
+                    description: >
+                        The inheritance configuration for I(ddns)clientI(update) field from I(IPSpace) object.
+                    type: dict
+                    returned: Always
+                    contains:
+                        action:
+                            description: >
+                                The inheritance setting for a field.
+                                
+                                Valid values are:
+                                * I(inherit): Use the inherited value.
+                                * I(override): Use the value set in the object.
+                                
+                                Defaults to I(inherit).
+                            type: str
+                            returned: Always
+                        display_name:
+                            description: >
+                                The human-readable display name for the object referred to by I(source).
+                            type: str
+                            returned: Always
+                        source:
+                            description: >
+                                The resource identifier.
+                            type: str
+                            returned: Always
+                        value:
+                            description: >
+                                The inherited value.
+                            type: str
+                            returned: Always
+                ddns_conflict_resolution_mode:
+                    description: >
+                        The inheritance configuration for I(ddns)conflictI(resolution)modeI( field from )IPSpace_ object.
+                    type: dict
+                    returned: Always
+                    contains:
+                        action:
+                            description: >
+                                The inheritance setting for a field.
+                                
+                                Valid values are:
+                                * I(inherit): Use the inherited value.
+                                * I(override): Use the value set in the object.
+                                
+                                Defaults to I(inherit).
+                            type: str
+                            returned: Always
+                        display_name:
+                            description: >
+                                The human-readable display name for the object referred to by I(source).
+                            type: str
+                            returned: Always
+                        source:
+                            description: >
+                                The resource identifier.
+                            type: str
+                            returned: Always
+                        value:
+                            description: >
+                                The inherited value.
+                            type: str
+                            returned: Always
+                ddns_enabled:
+                    description: >
+                        The inheritance configuration for I(ddns)enabled_ field. Only action allowed is 'inherit'.
+                    type: dict
+                    returned: Always
+                    contains:
+                        action:
+                            description: >
+                                The inheritance setting for a field.
+                                
+                                Valid values are:
+                                * I(inherit): Use the inherited value.
+                                * I(override): Use the value set in the object.
+                                
+                                Defaults to I(inherit).
+                            type: str
+                            returned: Always
+                        display_name:
+                            description: >
+                                The human-readable display name for the object referred to by I(source).
+                            type: str
+                            returned: Always
+                        source:
+                            description: >
+                                The resource identifier.
+                            type: str
+                            returned: Always
+                        value:
+                            description: >
+                                The inherited value.
+                            type: bool
+                            returned: Always
+                ddns_hostname_block:
+                    description: >
+                        The inheritance configuration for I(ddns)generateI(name) and I(ddns)generatedI(prefix) fields from I(IPSpace) object.
+                    type: dict
+                    returned: Always
+                    contains:
+                        action:
+                            description: >
+                                The inheritance setting.
+                                
+                                Valid values are:
+                                * I(inherit): Use the inherited value.
+                                * I(override): Use the value set in the object.
+                                
+                                Defaults to I(inherit).
+                            type: str
+                            returned: Always
+                        display_name:
+                            description: >
+                                The human-readable display name for the object referred to by I(source).
+                            type: str
+                            returned: Always
+                        source:
+                            description: >
+                                The resource identifier.
+                            type: str
+                            returned: Always
+                        value:
+                            description: >
+                                The inherited value.
+                            type: dict
+                            returned: Always
+                            contains:
+                                ddns_generate_name:
+                                    description: >
+                                        Indicates if DDNS should generate a hostname when not supplied by the client.
+                                    type: bool
+                                    returned: Always
+                                ddns_generated_prefix:
+                                    description: >
+                                        The prefix used in the generation of an FQDN.
+                                    type: str
+                                    returned: Always
+                ddns_ttl_percent:
+                    description: >
+                        The inheritance configuration for I(ddns)ttlI(percent) field from I(IPSpace) object.
+                    type: dict
+                    returned: Always
+                    contains:
+                        action:
+                            description: >
+                                The inheritance setting for a field.
+                                
+                                Valid values are:
+                                * I(inherit): Use the inherited value.
+                                * I(override): Use the value set in the object.
+                                
+                                Defaults to I(inherit).
+                            type: str
+                            returned: Always
+                        display_name:
+                            description: >
+                                The human-readable display name for the object referred to by I(source).
+                            type: str
+                            returned: Always
+                        source:
+                            description: >
+                                The resource identifier.
+                            type: str
+                            returned: Always
+                        value:
+                            description: >
+                                The inherited value.
+                            type: float
+                            returned: Always
+                ddns_update_block:
+                    description: >
+                        The inheritance configuration for I(ddns)sendI(updates) and I(ddns)domainI( fields from )IPSpace_ object.
+                    type: dict
+                    returned: Always
+                    contains:
+                        action:
+                            description: >
+                                The inheritance setting.
+                                
+                                Valid values are:
+                                * I(inherit): Use the inherited value.
+                                * I(override): Use the value set in the object.
+                                
+                                Defaults to I(inherit).
+                            type: str
+                            returned: Always
+                        display_name:
+                            description: >
+                                The human-readable display name for the object referred to by I(source).
+                            type: str
+                            returned: Always
+                        source:
+                            description: >
+                                The resource identifier.
+                            type: str
+                            returned: Always
+                        value:
+                            description: >
+                                The inherited value.
+                            type: dict
+                            returned: Always
+                            contains:
+                                ddns_domain:
+                                    description: >
+                                        The domain name for DDNS.
+                                    type: str
+                                    returned: Always
+                                ddns_send_updates:
+                                    description: >
+                                        Determines if DDNS updates are enabled at this level.
+                                    type: bool
+                                    returned: Always
+                ddns_update_on_renew:
+                    description: >
+                        The inheritance configuration for I(ddns)updateI(on)renewI( field from )IPSpace_ object.
+                    type: dict
+                    returned: Always
+                    contains:
+                        action:
+                            description: >
+                                The inheritance setting for a field.
+                                
+                                Valid values are:
+                                * I(inherit): Use the inherited value.
+                                * I(override): Use the value set in the object.
+                                
+                                Defaults to I(inherit).
+                            type: str
+                            returned: Always
+                        display_name:
+                            description: >
+                                The human-readable display name for the object referred to by I(source).
+                            type: str
+                            returned: Always
+                        source:
+                            description: >
+                                The resource identifier.
+                            type: str
+                            returned: Always
+                        value:
+                            description: >
+                                The inherited value.
+                            type: bool
+                            returned: Always
+                ddns_use_conflict_resolution:
+                    description: >
+                        The inheritance configuration for I(ddns)useI(conflict)resolutionI( field from )IPSpace_ object.
+                    type: dict
+                    returned: Always
+                    contains:
+                        action:
+                            description: >
+                                The inheritance setting for a field.
+                                
+                                Valid values are:
+                                * I(inherit): Use the inherited value.
+                                * I(override): Use the value set in the object.
+                                
+                                Defaults to I(inherit).
+                            type: str
+                            returned: Always
+                        display_name:
+                            description: >
+                                The human-readable display name for the object referred to by I(source).
+                            type: str
+                            returned: Always
+                        source:
+                            description: >
+                                The resource identifier.
+                            type: str
+                            returned: Always
+                        value:
+                            description: >
+                                The inherited value.
+                            type: bool
+                            returned: Always
+                dhcp_config:
+                    description: >
+                        The inheritance configuration for I(dhcp)config_ field.
+                    type: dict
+                    returned: Always
+                    contains:
+                        abandoned_reclaim_time:
+                            description: >
+                                The inheritance configuration for I(abandoned)reclaimI(time) field from I(DHCPConfig) object.
+                            type: dict
+                            returned: Always
+                            contains:
+                                action:
+                                    description: >
+                                        The inheritance setting for a field.
+                                        
+                                        Valid values are:
+                                        * I(inherit): Use the inherited value.
+                                        * I(override): Use the value set in the object.
+                                        
+                                        Defaults to I(inherit).
+                                    type: str
+                                    returned: Always
+                                display_name:
+                                    description: >
+                                        The human-readable display name for the object referred to by I(source).
+                                    type: str
+                                    returned: Always
+                                source:
+                                    description: >
+                                        The resource identifier.
+                                    type: str
+                                    returned: Always
+                                value:
+                                    description: >
+                                        The inherited value.
+                                    type: int
+                                    returned: Always
+                        abandoned_reclaim_time_v6:
+                            description: >
+                                The inheritance configuration for I(abandoned)reclaimI(time)v6I( field from )DHCPConfig_ object.
+                            type: dict
+                            returned: Always
+                            contains:
+                                action:
+                                    description: >
+                                        The inheritance setting for a field.
+                                        
+                                        Valid values are:
+                                        * I(inherit): Use the inherited value.
+                                        * I(override): Use the value set in the object.
+                                        
+                                        Defaults to I(inherit).
+                                    type: str
+                                    returned: Always
+                                display_name:
+                                    description: >
+                                        The human-readable display name for the object referred to by I(source).
+                                    type: str
+                                    returned: Always
+                                source:
+                                    description: >
+                                        The resource identifier.
+                                    type: str
+                                    returned: Always
+                                value:
+                                    description: >
+                                        The inherited value.
+                                    type: int
+                                    returned: Always
+                        allow_unknown:
+                            description: >
+                                The inheritance configuration for I(allow)unknownI( field from )DHCPConfig_ object.
+                            type: dict
+                            returned: Always
+                            contains:
+                                action:
+                                    description: >
+                                        The inheritance setting for a field.
+                                        
+                                        Valid values are:
+                                        * I(inherit): Use the inherited value.
+                                        * I(override): Use the value set in the object.
+                                        
+                                        Defaults to I(inherit).
+                                    type: str
+                                    returned: Always
+                                display_name:
+                                    description: >
+                                        The human-readable display name for the object referred to by I(source).
+                                    type: str
+                                    returned: Always
+                                source:
+                                    description: >
+                                        The resource identifier.
+                                    type: str
+                                    returned: Always
+                                value:
+                                    description: >
+                                        The inherited value.
+                                    type: bool
+                                    returned: Always
+                        allow_unknown_v6:
+                            description: >
+                                The inheritance configuration for I(allow)unknownI(v6) field from I(DHCPConfig) object.
+                            type: dict
+                            returned: Always
+                            contains:
+                                action:
+                                    description: >
+                                        The inheritance setting for a field.
+                                        
+                                        Valid values are:
+                                        * I(inherit): Use the inherited value.
+                                        * I(override): Use the value set in the object.
+                                        
+                                        Defaults to I(inherit).
+                                    type: str
+                                    returned: Always
+                                display_name:
+                                    description: >
+                                        The human-readable display name for the object referred to by I(source).
+                                    type: str
+                                    returned: Always
+                                source:
+                                    description: >
+                                        The resource identifier.
+                                    type: str
+                                    returned: Always
+                                value:
+                                    description: >
+                                        The inherited value.
+                                    type: bool
+                                    returned: Always
+                        echo_client_id:
+                            description: >
+                                The inheritance configuration for I(echo)clientI(id) field from I(DHCPConfig) object.
+                            type: dict
+                            returned: Always
+                            contains:
+                                action:
+                                    description: >
+                                        The inheritance setting for a field.
+                                        
+                                        Valid values are:
+                                        * I(inherit): Use the inherited value.
+                                        * I(override): Use the value set in the object.
+                                        
+                                        Defaults to I(inherit).
+                                    type: str
+                                    returned: Always
+                                display_name:
+                                    description: >
+                                        The human-readable display name for the object referred to by I(source).
+                                    type: str
+                                    returned: Always
+                                source:
+                                    description: >
+                                        The resource identifier.
+                                    type: str
+                                    returned: Always
+                                value:
+                                    description: >
+                                        The inherited value.
+                                    type: bool
+                                    returned: Always
+                        filters:
+                            description: >
+                                The inheritance configuration for filters field from I(DHCPConfig) object.
+                            type: dict
+                            returned: Always
+                            contains:
+                                action:
+                                    description: >
+                                        The inheritance setting.
+                                        
+                                        Valid values are:
+                                        * I(inherit): Use the inherited value.
+                                        * I(override): Use the value set in the object.
+                                        
+                                        Defaults to I(inherit).
+                                    type: str
+                                    returned: Always
+                                display_name:
+                                    description: >
+                                        The human-readable display name for the object referred to by I(source).
+                                    type: str
+                                    returned: Always
+                                source:
+                                    description: >
+                                        The resource identifier.
+                                    type: str
+                                    returned: Always
+                                value:
+                                    description: >
+                                        The resource identifier.
+                                    type: list
+                                    returned: Always
+                        filters_v6:
+                            description: >
+                                The inheritance configuration for I(filters)v6I( field from )DHCPConfig_ object.
+                            type: dict
+                            returned: Always
+                            contains:
+                                action:
+                                    description: >
+                                        The inheritance setting.
+                                        
+                                        Valid values are:
+                                        * I(inherit): Use the inherited value.
+                                        * I(override): Use the value set in the object.
+                                        
+                                        Defaults to I(inherit).
+                                    type: str
+                                    returned: Always
+                                display_name:
+                                    description: >
+                                        The human-readable display name for the object referred to by I(source).
+                                    type: str
+                                    returned: Always
+                                source:
+                                    description: >
+                                        The resource identifier.
+                                    type: str
+                                    returned: Always
+                                value:
+                                    description: >
+                                        The resource identifier.
+                                    type: list
+                                    returned: Always
+                        ignore_client_uid:
+                            description: >
+                                The inheritance configuration for I(ignore)clientI(uid) field from I(DHCPConfig) object.
+                            type: dict
+                            returned: Always
+                            contains:
+                                action:
+                                    description: >
+                                        The inheritance setting for a field.
+                                        
+                                        Valid values are:
+                                        * I(inherit): Use the inherited value.
+                                        * I(override): Use the value set in the object.
+                                        
+                                        Defaults to I(inherit).
+                                    type: str
+                                    returned: Always
+                                display_name:
+                                    description: >
+                                        The human-readable display name for the object referred to by I(source).
+                                    type: str
+                                    returned: Always
+                                source:
+                                    description: >
+                                        The resource identifier.
+                                    type: str
+                                    returned: Always
+                                value:
+                                    description: >
+                                        The inherited value.
+                                    type: bool
+                                    returned: Always
+                        ignore_list:
+                            description: >
+                                The inheritance configuration for I(ignore)listI( field from )DHCPConfig_ object.
+                            type: dict
+                            returned: Always
+                            contains:
+                                action:
+                                    description: >
+                                        The inheritance setting.
+                                        
+                                        Valid values are:
+                                        * I(inherit): Use the inherited value.
+                                        * I(override): Use the value set in the object.
+                                        
+                                        Defaults to I(inherit).
+                                    type: str
+                                    returned: Always
+                                display_name:
+                                    description: >
+                                        The human-readable display name for the object referred to by I(source).
+                                    type: str
+                                    returned: Always
+                                source:
+                                    description: >
+                                        The resource identifier.
+                                    type: str
+                                    returned: Always
+                                value:
+                                    description: >
+                                        The inherited value.
+                                    type: list
+                                    returned: Always
+                                    elements: dict
+                                    contains:
+                                        type:
+                                            description: >
+                                                Type of ignore matching: client to ignore by client identifier (client hex or client text) or hardware to ignore by hardware identifier (MAC address). It can have one of the following values:
+                                                * I(client)hex_,
+                                                * I(client)text_,
+                                                * I(hardware).
+                                            type: str
+                                            returned: Always
+                                        value:
+                                            description: >
+                                                Value to match.
+                                            type: str
+                                            returned: Always
+                        lease_time:
+                            description: >
+                                The inheritance configuration for I(lease)timeI( field from )DHCPConfig_ object.
+                            type: dict
+                            returned: Always
+                            contains:
+                                action:
+                                    description: >
+                                        The inheritance setting for a field.
+                                        
+                                        Valid values are:
+                                        * I(inherit): Use the inherited value.
+                                        * I(override): Use the value set in the object.
+                                        
+                                        Defaults to I(inherit).
+                                    type: str
+                                    returned: Always
+                                display_name:
+                                    description: >
+                                        The human-readable display name for the object referred to by I(source).
+                                    type: str
+                                    returned: Always
+                                source:
+                                    description: >
+                                        The resource identifier.
+                                    type: str
+                                    returned: Always
+                                value:
+                                    description: >
+                                        The inherited value.
+                                    type: int
+                                    returned: Always
+                        lease_time_v6:
+                            description: >
+                                The inheritance configuration for I(lease)timeI(v6) field from I(DHCPConfig) object.
+                            type: dict
+                            returned: Always
+                            contains:
+                                action:
+                                    description: >
+                                        The inheritance setting for a field.
+                                        
+                                        Valid values are:
+                                        * I(inherit): Use the inherited value.
+                                        * I(override): Use the value set in the object.
+                                        
+                                        Defaults to I(inherit).
+                                    type: str
+                                    returned: Always
+                                display_name:
+                                    description: >
+                                        The human-readable display name for the object referred to by I(source).
+                                    type: str
+                                    returned: Always
+                                source:
+                                    description: >
+                                        The resource identifier.
+                                    type: str
+                                    returned: Always
+                                value:
+                                    description: >
+                                        The inherited value.
+                                    type: int
+                                    returned: Always
+                dhcp_options:
+                    description: >
+                        The inheritance configuration for I(dhcp)options_ field.
+                    type: dict
+                    returned: Always
+                    contains:
+                        action:
+                            description: >
+                                The inheritance setting.
+                                
+                                Valid values are:
+                                * I(inherit): Use the inherited value.
+                                * I(block): Don't use the inherited value.
+                                
+                                Defaults to I(inherit).
+                            type: str
+                            returned: Always
+                        value:
+                            description: >
+                                The inherited DHCP option values.
+                            type: list
+                            returned: Always
+                            elements: dict
+                            contains:
+                                action:
+                                    description: >
+                                        The inheritance setting.
+                                        
+                                        Valid values are:
+                                        * I(inherit): Use the inherited value.
+                                        * I(block): Don't use the inherited value.
+                                        
+                                        Defaults to I(inherit).
+                                    type: str
+                                    returned: Always
+                                display_name:
+                                    description: >
+                                        The human-readable display name for the object referred to by I(source).
+                                    type: str
+                                    returned: Always
+                                source:
+                                    description: >
+                                        The resource identifier.
+                                    type: str
+                                    returned: Always
+                                value:
+                                    description: >
+                                        The inherited value for the DHCP option.
+                                    type: dict
+                                    returned: Always
+                                    contains:
+                                        option:
+                                            description: >
+                                                Option inherited from the ancestor.
+                                            type: dict
+                                            returned: Always
+                                            contains:
+                                                group:
+                                                    description: >
+                                                        The resource identifier.
+                                                    type: str
+                                                    returned: Always
+                                                option_code:
+                                                    description: >
+                                                        The resource identifier.
+                                                    type: str
+                                                    returned: Always
+                                                option_value:
+                                                    description: >
+                                                        The option value.
+                                                    type: str
+                                                    returned: Always
+                                                type:
+                                                    description: >
+                                                        The type of item.
+                                                        
+                                                        Valid values are:
+                                                        * I(group)
+                                                        * I(option)
+                                                    type: str
+                                                    returned: Always
+                                        overriding_group:
+                                            description: >
+                                                The resource identifier.
+                                            type: str
+                                            returned: Always
+                dhcp_options_v6:
+                    description: >
+                        The inheritance configuration for I(dhcp)optionsI(v6) field.
+                    type: dict
+                    returned: Always
+                    contains:
+                        action:
+                            description: >
+                                The inheritance setting.
+                                
+                                Valid values are:
+                                * I(inherit): Use the inherited value.
+                                * I(block): Don't use the inherited value.
+                                
+                                Defaults to I(inherit).
+                            type: str
+                            returned: Always
+                        value:
+                            description: >
+                                The inherited DHCP option values.
+                            type: list
+                            returned: Always
+                            elements: dict
+                            contains:
+                                action:
+                                    description: >
+                                        The inheritance setting.
+                                        
+                                        Valid values are:
+                                        * I(inherit): Use the inherited value.
+                                        * I(block): Don't use the inherited value.
+                                        
+                                        Defaults to I(inherit).
+                                    type: str
+                                    returned: Always
+                                display_name:
+                                    description: >
+                                        The human-readable display name for the object referred to by I(source).
+                                    type: str
+                                    returned: Always
+                                source:
+                                    description: >
+                                        The resource identifier.
+                                    type: str
+                                    returned: Always
+                                value:
+                                    description: >
+                                        The inherited value for the DHCP option.
+                                    type: dict
+                                    returned: Always
+                                    contains:
+                                        option:
+                                            description: >
+                                                Option inherited from the ancestor.
+                                            type: dict
+                                            returned: Always
+                                            contains:
+                                                group:
+                                                    description: >
+                                                        The resource identifier.
+                                                    type: str
+                                                    returned: Always
+                                                option_code:
+                                                    description: >
+                                                        The resource identifier.
+                                                    type: str
+                                                    returned: Always
+                                                option_value:
+                                                    description: >
+                                                        The option value.
+                                                    type: str
+                                                    returned: Always
+                                                type:
+                                                    description: >
+                                                        The type of item.
+                                                        
+                                                        Valid values are:
+                                                        * I(group)
+                                                        * I(option)
+                                                    type: str
+                                                    returned: Always
+                                        overriding_group:
+                                            description: >
+                                                The resource identifier.
+                                            type: str
+                                            returned: Always
+                header_option_filename:
+                    description: >
+                        The inheritance configuration for I(header)optionI(filename) field.
+                    type: dict
+                    returned: Always
+                    contains:
+                        action:
+                            description: >
+                                The inheritance setting for a field.
+                                
+                                Valid values are:
+                                * I(inherit): Use the inherited value.
+                                * I(override): Use the value set in the object.
+                                
+                                Defaults to I(inherit).
+                            type: str
+                            returned: Always
+                        display_name:
+                            description: >
+                                The human-readable display name for the object referred to by I(source).
+                            type: str
+                            returned: Always
+                        source:
+                            description: >
+                                The resource identifier.
+                            type: str
+                            returned: Always
+                        value:
+                            description: >
+                                The inherited value.
+                            type: str
+                            returned: Always
+                header_option_server_address:
+                    description: >
+                        The inheritance configuration for I(header)optionI(server)address_ field.
+                    type: dict
+                    returned: Always
+                    contains:
+                        action:
+                            description: >
+                                The inheritance setting for a field.
+                                
+                                Valid values are:
+                                * I(inherit): Use the inherited value.
+                                * I(override): Use the value set in the object.
+                                
+                                Defaults to I(inherit).
+                            type: str
+                            returned: Always
+                        display_name:
+                            description: >
+                                The human-readable display name for the object referred to by I(source).
+                            type: str
+                            returned: Always
+                        source:
+                            description: >
+                                The resource identifier.
+                            type: str
+                            returned: Always
+                        value:
+                            description: >
+                                The inherited value.
+                            type: str
+                            returned: Always
+                header_option_server_name:
+                    description: >
+                        The inheritance configuration for I(header)optionI(server)name_ field.
+                    type: dict
+                    returned: Always
+                    contains:
+                        action:
+                            description: >
+                                The inheritance setting for a field.
+                                
+                                Valid values are:
+                                * I(inherit): Use the inherited value.
+                                * I(override): Use the value set in the object.
+                                
+                                Defaults to I(inherit).
+                            type: str
+                            returned: Always
+                        display_name:
+                            description: >
+                                The human-readable display name for the object referred to by I(source).
+                            type: str
+                            returned: Always
+                        source:
+                            description: >
+                                The resource identifier.
+                            type: str
+                            returned: Always
+                        value:
+                            description: >
+                                The inherited value.
+                            type: str
+                            returned: Always
+                hostname_rewrite_block:
+                    description: >
+                        The inheritance configuration for I(hostname)rewriteI(enabled), I(hostname)rewriteI(regex), and I(hostname)rewriteI(char) fields from I(IPSpace) object.
+                    type: dict
+                    returned: Always
+                    contains:
+                        action:
+                            description: >
+                                The inheritance setting.
+                                
+                                Valid values are:
+                                * I(inherit): Use the inherited value.
+                                * I(override): Use the value set in the object.
+                                
+                                Defaults to I(inherit).
+                            type: str
+                            returned: Always
+                        display_name:
+                            description: >
+                                The human-readable display name for the object referred to by I(source).
+                            type: str
+                            returned: Always
+                        source:
+                            description: >
+                                The resource identifier.
+                            type: str
+                            returned: Always
+                        value:
+                            description: >
+                                The inherited value.
+                            type: dict
+                            returned: Always
+                            contains:
+                                hostname_rewrite_char:
+                                    description: >
+                                        The inheritance configuration for I(hostname)rewriteI(char) field.
+                                    type: str
+                                    returned: Always
+                                hostname_rewrite_enabled:
+                                    description: >
+                                        The inheritance configuration for I(hostname)rewriteI(enabled) field.
+                                    type: bool
+                                    returned: Always
+                                hostname_rewrite_regex:
+                                    description: >
+                                        The inheritance configuration for I(hostname)rewriteI(regex) field.
+                                    type: str
+                                    returned: Always
+                vendor_specific_option_option_space:
+                    description: >
+                        The inheritance configuration for I(vendor)specificI(option)optionI(space) field.
+                    type: dict
+                    returned: Always
+                    contains:
+                        action:
+                            description: >
+                                The inheritance setting for a field.
+                                
+                                Valid values are:
+                                * I(inherit): Use the inherited value.
+                                * I(override): Use the value set in the object.
+                                
+                                Defaults to I(inherit).
+                            type: str
+                            returned: Always
+                        display_name:
+                            description: >
+                                The human-readable display name for the object referred to by I(source).
+                            type: str
+                            returned: Always
+                        source:
+                            description: >
+                                The resource identifier.
+                            type: str
+                            returned: Always
+                        value:
+                            description: >
+                                The resource identifier.
+                            type: str
+                            returned: Always
+        name:
+            description: >
+                The name of the IP space. Must contain 1 to 256 characters. Can include UTF-8.
+            type: str
+            returned: Always
+        tags:
+            description: >
+                The tags for the IP space in JSON format.
+            type: dict
+            returned: Always
+        threshold:
+            description: >
+                The utilization threshold settings for the IP space.
+            type: dict
+            returned: Always
+            contains:
+                enabled:
+                    description: >
+                        Indicates whether the utilization threshold for IP addresses is enabled or not.
+                    type: bool
+                    returned: Always
+                high:
+                    description: >
+                        The high threshold value for the percentage of used IP addresses relative to the total IP addresses available in the scope of the object. Thresholds are inclusive in the comparison test.
+                    type: int
+                    returned: Always
+                low:
+                    description: >
+                        The low threshold value for the percentage of used IP addresses relative to the total IP addresses available in the scope of the object. Thresholds are inclusive in the comparison test.
+                    type: int
+                    returned: Always
+        updated_at:
+            description: >
+                Time when the object has been updated. Equals to I(created)at_ if not updated after creation.
+            type: str
+            returned: Always
+        utilization:
+            description: >
+                The utilization of IPV4 addresses in the IP space.
+            type: dict
+            returned: Always
+            contains:
+                abandon_utilization:
+                    description: >
+                        The percentage of abandoned IP addresses relative to the total IP addresses available in the scope of the object.
+                    type: int
+                    returned: Always
+                abandoned:
+                    description: >
+                        The number of IP addresses in the scope of the object which are in the abandoned state (issued by a DHCP server and then declined by the client).
+                    type: str
+                    returned: Always
+                dynamic:
+                    description: >
+                        The number of IP addresses handed out by DHCP in the scope of the object. This includes all leased addresses, fixed addresses that are defined but not currently leased and abandoned leases.
+                    type: str
+                    returned: Always
+                free:
+                    description: >
+                        The number of IP addresses available in the scope of the object.
+                    type: str
+                    returned: Always
+                static:
+                    description: >
+                        The number of defined IP addresses such as reservations or DNS records. It can be computed as I(static) = I(used) - I(dynamic).
+                    type: str
+                    returned: Always
+                total:
+                    description: >
+                        The total number of IP addresses available in the scope of the object.
+                    type: str
+                    returned: Always
+                used:
+                    description: >
+                        The number of IP addresses used in the scope of the object.
+                    type: str
+                    returned: Always
+                utilization:
+                    description: >
+                        The percentage of used IP addresses relative to the total IP addresses available in the scope of the object.
+                    type: int
+                    returned: Always
+        utilization_v6:
+            description: >
+                The utilization of IPV6 addresses in the IP space.
+            type: dict
+            returned: Always
+            contains:
+                abandoned:
+                    description: ""
+                    type: str
+                    returned: Always
+                dynamic:
+                    description: ""
+                    type: str
+                    returned: Always
+                static:
+                    description: ""
+                    type: str
+                    returned: Always
+                total:
+                    description: ""
+                    type: str
+                    returned: Always
+                used:
+                    description: ""
+                    type: str
+                    returned: Always
+        vendor_specific_option_option_space:
+            description: >
+                The resource identifier.
+            type: str
+            returned: Always
+"""  # noqa: E501
+
+from ansible_collections.infoblox.bloxone.plugins.module_utils.modules import BloxoneAnsibleModule
+
+try:
+    from bloxone_client import ApiException, NotFoundException
+    from ipam import IpSpaceApi
+except ImportError:
+    pass  # Handled by BloxoneAnsibleModule
+
+
+class IpSpaceInfoModule(BloxoneAnsibleModule):
+    def __init__(self, *args, **kwargs):
+        super(IpSpaceInfoModule, self).__init__(*args, **kwargs)
+        self._existing = None
+        self._limit = 1000
+
+    def find_by_id(self):
+        try:
+            resp = IpSpaceApi(self.client).read(self.params["id"], inherit="full")
+            return [resp.result]
+        except NotFoundException as e:
+            return None
+
+    def find(self):
+        if self.params["id"] is not None:
+            return self.find_by_id()
+
+        filter_str = None
+        if self.params["filters"] is not None:
+            filter_str = " and ".join([f"{k}=='{v}'" for k, v in self.params["filters"].items()])
+        elif self.params["filter_query"] is not None:
+            filter_str = self.params["filter_query"]
+
+        tag_filter_str = None
+        if self.params["tag_filters"] is not None:
+            tag_filter_str = " and ".join([f"{k}=='{v}'" for k, v in self.params["tag_filters"].items()])
+        elif self.params["tag_filter_query"] is not None:
+            tag_filter_str = self.params["tag_filter_query"]
+
+        all_results = []
+        offset = 0
+
+        while True:
+            try:
+                resp = IpSpaceApi(self.client).list(
+                    filter=filter_str, tfilter=tag_filter_str, inherit="full", offset=offset, limit=self._limit
+                )
+                all_results.extend(resp.results)
+
+                if len(resp.results) < self._limit:
+                    break
+                offset += self._limit
+
+            except ApiException as e:
+                self.fail_json(msg=f"Failed to execute command: {e.status} {e.reason} {e.body}")
+
+        resp = IpSpaceApi(self.client).list(filter=filter_str, tfilter=tag_filter_str, inherit="full")
+        return resp.results
+
+    def run_command(self):
+        result = dict(results=[])
+
+        if self.check_mode:
+            self.exit_json(**result)
+
+        find_results = self.find()
+
+        all_results = []
+        for r in find_results:
+            all_results.append(r.model_dump(by_alias=True, exclude_none=True))
+
+        result["results"] = all_results
+        self.exit_json(**result)
+
+
+def main():
+    # define available arguments/parameters a user can pass to the module
+    module_args = dict(
+        id=dict(type="str", required=False),
+        filters=dict(type="dict", required=False),
+        filter_query=dict(type="str", required=False),
+        inherit=dict(type="str", required=False, choices=["full", "partial", "none"], default="full"),
+        tag_filters=dict(type="dict", required=False),
+        tag_filter_query=dict(type="str", required=False),
+    )
+
+    module = IpSpaceInfoModule(
+        argument_spec=module_args,
+        supports_check_mode=True,
+        mutually_exclusive=[
+            ["id", "filters", "filter_query"],
+            ["id", "tag_filters", "tag_filter_query"],
+        ],
+    )
+    module.run_command()
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/ipam_ip_space_info.py
+++ b/plugins/modules/ipam_ip_space_info.py
@@ -10,9 +10,10 @@ __metaclass__ = type
 DOCUMENTATION = r"""
 ---
 module: ipam_ip_space_info
-short_description: Manage IpSpace
+short_description: Retrieves information about existing IP Spaces.
 description:
-    - Manage IpSpace
+    - Retrieves information about existing IP Spaces.
+    - The IP Space object represents an entire address space
 version_added: 2.0.0
 author: Infoblox Inc. (@infobloxopen)
 options:
@@ -1714,9 +1715,9 @@ except ImportError:
     pass  # Handled by BloxoneAnsibleModule
 
 
-class IpSpaceInfoModule(BloxoneAnsibleModule):
+class IPSpaceInfoModule(BloxoneAnsibleModule):
     def __init__(self, *args, **kwargs):
-        super(IpSpaceInfoModule, self).__init__(*args, **kwargs)
+        super(IPSpaceInfoModule, self).__init__(*args, **kwargs)
         self._existing = None
         self._limit = 1000
 
@@ -1789,7 +1790,7 @@ def main():
         tag_filter_query=dict(type="str", required=False),
     )
 
-    module = IpSpaceInfoModule(
+    module = IPSpaceInfoModule(
         argument_spec=module_args,
         supports_check_mode=True,
         mutually_exclusive=[

--- a/plugins/modules/ipam_ip_space_info.py
+++ b/plugins/modules/ipam_ip_space_info.py
@@ -90,55 +90,54 @@ objects:
     returned: Always
     contains:
         asm_config:
-            description: >
-                The Automated Scope Management configuration for the IP space.
+            description:
+                - "The Automated Scope Management configuration for the IP space."
             type: dict
             returned: Always
             contains:
                 asm_threshold:
-                    description: >
-                        ASM shows the number of addresses forecast to be used I(forecast)periodI( days in the future, if it is greater than )asmI(threshold) percent * I(dhcp)totalI( (see )dhcpI(utilization)) then the subnet is flagged.
+                    description:
+                        - "ASM shows the number of addresses forecast to be used I(forecast_period) days in the future, if it is greater than I(asm_threshold) percent * I(dhcp_total) (see I(dhcp_utilization)) then the subnet is flagged."
                     type: int
                     returned: Always
                 enable:
-                    description: >
-                        Indicates if Automated Scope Management is enabled.
+                    description:
+                        - "Indicates if Automated Scope Management is enabled."
                     type: bool
                     returned: Always
                 enable_notification:
-                    description: >
-                        Indicates if ASM should send notifications to the user.
+                    description:
+                        - "Indicates if ASM should send notifications to the user."
                     type: bool
                     returned: Always
                 forecast_period:
-                    description: >
-                        The forecast period in days.
+                    description:
+                        - "The forecast period in days."
                     type: int
                     returned: Always
                 growth_factor:
-                    description: >
-                        Indicates the growth in the number or percentage of IP addresses.
+                    description:
+                        - "Indicates the growth in the number or percentage of IP addresses."
                     type: int
                     returned: Always
                 growth_type:
-                    description: >
-                        The type of factor to use: I(percent) or I(count).
+                    description:
+                        - "The type of factor to use: I(percent) or I(count)."
                     type: str
                     returned: Always
                 history:
-                    description: >
-                        The minimum amount of history needed before ASM can run on this subnet.
+                    description:
+                        - "The minimum amount of history needed before ASM can run on this subnet."
                     type: int
                     returned: Always
                 min_total:
-                    description: >
-                        The minimum size of range needed for ASM to run on this subnet.
+                    description:
+                        - "The minimum size of range needed for ASM to run on this subnet."
                     type: int
                     returned: Always
                 min_unused:
-                    description: >
-                        The minimum percentage of addresses that must be available outside of the DHCP ranges and fixed addresses
-                        when making a suggested change..
+                    description:
+                        - "The minimum percentage of addresses that must be available outside of the DHCP ranges and fixed addresses when making a suggested change.."
                     type: int
                     returned: Always
                 reenable_date:
@@ -146,1630 +145,1536 @@ objects:
                     type: str
                     returned: Always
         asm_scope_flag:
-            description: >
-                The number of times the automated scope management usage limits have been exceeded for any of the subnets in this IP space.
+            description:
+                - "The number of times the automated scope management usage limits have been exceeded for any of the subnets in this IP space."
             type: int
             returned: Always
         comment:
-            description: >
-                The description for the IP space. May contain 0 to 1024 characters. Can include UTF-8.
+            description:
+                - "The description for the IP space. May contain 0 to 1024 characters. Can include UTF-8."
             type: str
             returned: Always
         created_at:
-            description: >
-                Time when the object has been created.
+            description:
+                - "Time when the object has been created."
             type: str
             returned: Always
         ddns_client_update:
-            description: >
-                Controls who does the DDNS updates.
-                
-                Valid values are:
-                * I(client): DHCP server updates DNS if requested by client.
-                * I(server): DHCP server always updates DNS, overriding an update request from the client, unless the client requests no updates.
-                * I(ignore): DHCP server always updates DNS, even if the client says not to.
-                * I(over)clientI(update): Same as I(server). DHCP server always updates DNS, overriding an update request from the client, unless the client requests no updates.
-                * I(over)noI(update): DHCP server updates DNS even if the client requests that no updates be done. If the client requests to do the update, DHCP server allows it.
-                
-                Defaults to I(client).
+            description:
+                - "Controls who does the DDNS updates."
+                - "Valid values are:"
+                - "* I(client): DHCP server updates DNS if requested by client."
+                - "* I(server): DHCP server always updates DNS, overriding an update request from the client, unless the client requests no updates."
+                - "* I(ignore): DHCP server always updates DNS, even if the client says not to."
+                - "* I(over_client_update): Same as I(server). DHCP server always updates DNS, overriding an update request from the client, unless the client requests no updates."
+                - "* I(over_no_update): DHCP server updates DNS even if the client requests that no updates be done. If the client requests to do the update, DHCP server allows it."
+                - "Defaults to I(client)."
             type: str
             returned: Always
         ddns_conflict_resolution_mode:
-            description: >
-                The mode used for resolving conflicts while performing DDNS updates.
-                
-                Valid values are:
-                * I(check)withI(dhcid): It includes adding a DHCID record and checking that record via conflict detection as per RFC 4703.
-                * I(no)checkI(with)dhcid_: This will ignore conflict detection but add a DHCID record when creating/updating an entry.
-                * I(check)existsI(with)dhcid_: This will check if there is an existing DHCID record but does not verify the value of the record matches the update. This will also update the DHCID record for the entry.
-                * I(no)checkI(without)dhcid_: This ignores conflict detection and will not add a DHCID record when creating/updating a DDNS entry.
-                
-                Defaults to I(check)withI(dhcid).
+            description:
+                - "The mode used for resolving conflicts while performing DDNS updates."
+                - "Valid values are:"
+                - "* I(check_with_dhcid): It includes adding a DHCID record and checking that record via conflict detection as per RFC 4703."
+                - "* I(no_check_with_dhcid): This will ignore conflict detection but add a DHCID record when creating/updating an entry."
+                - "* I(check_exists_with_dhcid): This will check if there is an existing DHCID record but does not verify the value of the record matches the update. This will also update the DHCID record for the entry."
+                - "* I(no_check_without_dhcid): This ignores conflict detection and will not add a DHCID record when creating/updating a DDNS entry."
+                - "Defaults to I(check_with_dhcid)."
             type: str
             returned: Always
         ddns_domain:
-            description: >
-                The domain suffix for DDNS updates. FQDN, may be empty.
-                
-                Defaults to empty.
+            description:
+                - "The domain suffix for DDNS updates. FQDN, may be empty."
+                - "Defaults to empty."
             type: str
             returned: Always
         ddns_generate_name:
-            description: >
-                Indicates if DDNS needs to generate a hostname when not supplied by the client.
-                
-                Defaults to I(false).
+            description:
+                - "Indicates if DDNS needs to generate a hostname when not supplied by the client."
+                - "Defaults to I(false)."
             type: bool
             returned: Always
         ddns_generated_prefix:
-            description: >
-                The prefix used in the generation of an FQDN.
-                
-                When generating a name, DHCP server will construct the name in the format: [ddns-generated-prefix]-[address-text].[ddns-qualifying-suffix].
-                where address-text is simply the lease IP address converted to a hyphenated string.
-                
-                Defaults to "myhost".
+            description:
+                - "The prefix used in the generation of an FQDN."
+                - "When generating a name, DHCP server will construct the name in the format: [ddns-generated-prefix]-[address-text].[ddns-qualifying-suffix]. where address-text is simply the lease IP address converted to a hyphenated string."
+                - "Defaults to &quot;myhost&quot;."
             type: str
             returned: Always
         ddns_send_updates:
-            description: >
-                Determines if DDNS updates are enabled at the IP space level.
-                Defaults to I(true).
+            description:
+                - "Determines if DDNS updates are enabled at the IP space level. Defaults to I(true)."
             type: bool
             returned: Always
         ddns_ttl_percent:
-            description: >
-                DDNS TTL value - to be calculated as a simple percentage of the lease's lifetime, using the parameter's value as the percentage.
-                It is specified as a percentage (e.g. 25, 75).
-                Defaults to unspecified.
+            description:
+                - "DDNS TTL value - to be calculated as a simple percentage of the lease&#x27;s lifetime, using the parameter&#x27;s value as the percentage. It is specified as a percentage (e.g. 25, 75). Defaults to unspecified."
             type: float
             returned: Always
         ddns_update_on_renew:
-            description: >
-                Instructs the DHCP server to always update the DNS information when a lease is renewed even if its DNS information has not changed.
-                
-                Defaults to I(false).
+            description:
+                - "Instructs the DHCP server to always update the DNS information when a lease is renewed even if its DNS information has not changed."
+                - "Defaults to I(false)."
             type: bool
             returned: Always
         ddns_use_conflict_resolution:
-            description: >
-                When true, DHCP server will apply conflict resolution, as described in RFC 4703, when attempting to fulfill the update request.
-                
-                When false, DHCP server will simply attempt to update the DNS entries per the request, regardless of whether or not they conflict with existing entries owned by other DHCP4 clients.
-                
-                Defaults to I(true).
+            description:
+                - "When true, DHCP server will apply conflict resolution, as described in RFC 4703, when attempting to fulfill the update request."
+                - "When false, DHCP server will simply attempt to update the DNS entries per the request, regardless of whether or not they conflict with existing entries owned by other DHCP4 clients."
+                - "Defaults to I(true)."
             type: bool
             returned: Always
         dhcp_config:
-            description: >
-                The shared DHCP configuration for the IP space that controls how leases are issued.
+            description:
+                - "The shared DHCP configuration for the IP space that controls how leases are issued."
             type: dict
             returned: Always
             contains:
                 abandoned_reclaim_time:
-                    description: >
-                        The abandoned reclaim time in seconds for IPV4 clients.
+                    description:
+                        - "The abandoned reclaim time in seconds for IPV4 clients."
                     type: int
                     returned: Always
                 abandoned_reclaim_time_v6:
-                    description: >
-                        The abandoned reclaim time in seconds for IPV6 clients.
+                    description:
+                        - "The abandoned reclaim time in seconds for IPV6 clients."
                     type: int
                     returned: Always
                 allow_unknown:
-                    description: >
-                        Disable to allow leases only for known IPv4 clients, those for which a fixed address is configured.
+                    description:
+                        - "Disable to allow leases only for known IPv4 clients, those for which a fixed address is configured."
                     type: bool
                     returned: Always
                 allow_unknown_v6:
-                    description: >
-                        Disable to allow leases only for known IPV6 clients, those for which a fixed address is configured.
+                    description:
+                        - "Disable to allow leases only for known IPV6 clients, those for which a fixed address is configured."
                     type: bool
                     returned: Always
                 echo_client_id:
-                    description: >
-                        Enable/disable to include/exclude the client id when responding to discover or request.
+                    description:
+                        - "Enable/disable to include/exclude the client id when responding to discover or request."
                     type: bool
                     returned: Always
                 filters:
-                    description: >
-                        The resource identifier.
+                    description:
+                        - "The resource identifier."
                     type: list
                     returned: Always
                 filters_v6:
-                    description: >
-                        The resource identifier.
+                    description:
+                        - "The resource identifier."
                     type: list
                     returned: Always
                 ignore_client_uid:
-                    description: >
-                        Enable to ignore the client UID when issuing a DHCP lease. Use this option to prevent assigning two IP addresses for a client which does not have a UID during one phase of PXE boot but acquires one for the other phase.
+                    description:
+                        - "Enable to ignore the client UID when issuing a DHCP lease. Use this option to prevent assigning two IP addresses for a client which does not have a UID during one phase of PXE boot but acquires one for the other phase."
                     type: bool
                     returned: Always
                 ignore_list:
-                    description: >
-                        The list of clients to ignore requests from.
+                    description:
+                        - "The list of clients to ignore requests from."
                     type: list
                     returned: Always
                     elements: dict
                     contains:
                         type:
-                            description: >
-                                Type of ignore matching: client to ignore by client identifier (client hex or client text) or hardware to ignore by hardware identifier (MAC address). It can have one of the following values:
-                                * I(client)hex_,
-                                * I(client)text_,
-                                * I(hardware).
+                            description:
+                                - "Type of ignore matching: client to ignore by client identifier (client hex or client text) or hardware to ignore by hardware identifier (MAC address). It can have one of the following values:"
+                                - "* I(client_hex),"
+                                - "* I(client_text),"
+                                - "* I(hardware)."
                             type: str
                             returned: Always
                         value:
-                            description: >
-                                Value to match.
+                            description:
+                                - "Value to match."
                             type: str
                             returned: Always
                 lease_time:
-                    description: >
-                        The lease duration in seconds.
+                    description:
+                        - "The lease duration in seconds."
                     type: int
                     returned: Always
                 lease_time_v6:
-                    description: >
-                        The lease duration in seconds for IPV6 clients.
+                    description:
+                        - "The lease duration in seconds for IPV6 clients."
                     type: int
                     returned: Always
         dhcp_options:
-            description: >
-                The list of IPv4 DHCP options for IP space. May be either a specific option or a group of options.
+            description:
+                - "The list of IPv4 DHCP options for IP space. May be either a specific option or a group of options."
             type: list
             returned: Always
             elements: dict
             contains:
                 group:
-                    description: >
-                        The resource identifier.
+                    description:
+                        - "The resource identifier."
                     type: str
                     returned: Always
                 option_code:
-                    description: >
-                        The resource identifier.
+                    description:
+                        - "The resource identifier."
                     type: str
                     returned: Always
                 option_value:
-                    description: >
-                        The option value.
+                    description:
+                        - "The option value."
                     type: str
                     returned: Always
                 type:
-                    description: >
-                        The type of item.
-                        
-                        Valid values are:
-                        * I(group)
-                        * I(option)
+                    description:
+                        - "The type of item."
+                        - "Valid values are:"
+                        - "* I(group)"
+                        - "* I(option)"
                     type: str
                     returned: Always
         dhcp_options_v6:
-            description: >
-                The list of IPv6 DHCP options for IP space. May be either a specific option or a group of options.
+            description:
+                - "The list of IPv6 DHCP options for IP space. May be either a specific option or a group of options."
             type: list
             returned: Always
             elements: dict
             contains:
                 group:
-                    description: >
-                        The resource identifier.
+                    description:
+                        - "The resource identifier."
                     type: str
                     returned: Always
                 option_code:
-                    description: >
-                        The resource identifier.
+                    description:
+                        - "The resource identifier."
                     type: str
                     returned: Always
                 option_value:
-                    description: >
-                        The option value.
+                    description:
+                        - "The option value."
                     type: str
                     returned: Always
                 type:
-                    description: >
-                        The type of item.
-                        
-                        Valid values are:
-                        * I(group)
-                        * I(option)
+                    description:
+                        - "The type of item."
+                        - "Valid values are:"
+                        - "* I(group)"
+                        - "* I(option)"
                     type: str
                     returned: Always
         header_option_filename:
-            description: >
-                The configuration for header option filename field.
+            description:
+                - "The configuration for header option filename field."
             type: str
             returned: Always
         header_option_server_address:
-            description: >
-                The configuration for header option server address field.
+            description:
+                - "The configuration for header option server address field."
             type: str
             returned: Always
         header_option_server_name:
-            description: >
-                The configuration for header option server name field.
+            description:
+                - "The configuration for header option server name field."
             type: str
             returned: Always
         hostname_rewrite_char:
-            description: >
-                The character to replace non-matching characters with, when hostname rewrite is enabled.
-                
-                Any single ASCII character or no character if the invalid characters should be removed without replacement.
-                
-                Defaults to "-".
+            description:
+                - "The character to replace non-matching characters with, when hostname rewrite is enabled."
+                - "Any single ASCII character or no character if the invalid characters should be removed without replacement."
+                - "Defaults to &quot;-&quot;."
             type: str
             returned: Always
         hostname_rewrite_enabled:
-            description: >
-                Indicates if client supplied hostnames will be rewritten prior to DDNS update by replacing every character that does not match I(hostname)rewriteI(regex) by I(hostname)rewriteI(char).
-                
-                Defaults to I(false).
+            description:
+                - "Indicates if client supplied hostnames will be rewritten prior to DDNS update by replacing every character that does not match I(hostname_rewrite_regex) by I(hostname_rewrite_char)."
+                - "Defaults to I(false)."
             type: bool
             returned: Always
         hostname_rewrite_regex:
-            description: >
-                The regex bracket expression to match valid characters.
-                
-                Must begin with "[" and end with "]" and be a compilable POSIX regex.
-                
-                Defaults to "[^a-zA-Z0-9_.]".
+            description:
+                - "The regex bracket expression to match valid characters."
+                - "Must begin with &quot;[&quot; and end with &quot;]&quot; and be a compilable POSIX regex."
+                - "Defaults to &quot;[^a-zA-Z0-9_.]&quot;."
             type: str
             returned: Always
         id:
-            description: >
-                The resource identifier.
+            description:
+                - "The resource identifier."
             type: str
             returned: Always
         inheritance_sources:
-            description: >
-                The inheritance configuration.
+            description:
+                - "The inheritance configuration."
             type: dict
             returned: Always
             contains:
                 asm_config:
-                    description: >
-                        The inheritance configuration for I(asm)config_ field.
+                    description:
+                        - "The inheritance configuration for I(asm_config) field."
                     type: dict
                     returned: Always
                     contains:
                         asm_enable_block:
-                            description: >
-                                The block of ASM fields: I(enable), I(enable)notificationI(, )reenableI(date).
+                            description:
+                                - "The block of ASM fields: I(enable), I(enable_notification), I(reenable_date)."
                             type: dict
                             returned: Always
                             contains:
                                 action:
-                                    description: >
-                                        The inheritance setting.
-                                        
-                                        Valid values are:
-                                        * I(inherit): Use the inherited value.
-                                        * I(override): Use the value set in the object.
-                                        
-                                        Defaults to I(inherit).
+                                    description:
+                                        - "The inheritance setting."
+                                        - "Valid values are:"
+                                        - "* I(inherit): Use the inherited value."
+                                        - "* I(override): Use the value set in the object."
+                                        - "Defaults to I(inherit)."
                                     type: str
                                     returned: Always
                                 display_name:
-                                    description: >
-                                        The human-readable display name for the object referred to by I(source).
+                                    description:
+                                        - "The human-readable display name for the object referred to by I(source)."
                                     type: str
                                     returned: Always
                                 source:
-                                    description: >
-                                        The resource identifier.
+                                    description:
+                                        - "The resource identifier."
                                     type: str
                                     returned: Always
                                 value:
-                                    description: >
-                                        The inherited value.
+                                    description:
+                                        - "The inherited value."
                                     type: dict
                                     returned: Always
                                     contains:
                                         enable:
-                                            description: >
-                                                Indicates whether Automated Scope Management is enabled or not.
+                                            description:
+                                                - "Indicates whether Automated Scope Management is enabled or not."
                                             type: bool
                                             returned: Always
                                         enable_notification:
-                                            description: >
-                                                Indicates whether sending notifications to the users is enabled or not.
+                                            description:
+                                                - "Indicates whether sending notifications to the users is enabled or not."
                                             type: bool
                                             returned: Always
                                         reenable_date:
-                                            description: >
-                                                The date at which notifications will be re-enabled automatically.
+                                            description:
+                                                - "The date at which notifications will be re-enabled automatically."
                                             type: str
                                             returned: Always
                         asm_growth_block:
-                            description: >
-                                The block of ASM fields: I(growth)factorI(, )growthI(type).
+                            description:
+                                - "The block of ASM fields: I(growth_factor), I(growth_type)."
                             type: dict
                             returned: Always
                             contains:
                                 action:
-                                    description: >
-                                        The inheritance setting.
-                                        
-                                        Valid values are:
-                                        * I(inherit): Use the inherited value.
-                                        * I(override): Use the value set in the object.
-                                        
-                                        Defaults to I(inherit).
+                                    description:
+                                        - "The inheritance setting."
+                                        - "Valid values are:"
+                                        - "* I(inherit): Use the inherited value."
+                                        - "* I(override): Use the value set in the object."
+                                        - "Defaults to I(inherit)."
                                     type: str
                                     returned: Always
                                 display_name:
-                                    description: >
-                                        The human-readable display name for the object referred to by I(source).
+                                    description:
+                                        - "The human-readable display name for the object referred to by I(source)."
                                     type: str
                                     returned: Always
                                 source:
-                                    description: >
-                                        The resource identifier.
+                                    description:
+                                        - "The resource identifier."
                                     type: str
                                     returned: Always
                                 value:
-                                    description: >
-                                        The inherited value.
+                                    description:
+                                        - "The inherited value."
                                     type: dict
                                     returned: Always
                                     contains:
                                         growth_factor:
-                                            description: >
-                                                Either the number or percentage of addresses to grow by.
+                                            description:
+                                                - "Either the number or percentage of addresses to grow by."
                                             type: int
                                             returned: Always
                                         growth_type:
-                                            description: >
-                                                The type of factor to use: I(percent) or I(count).
+                                            description:
+                                                - "The type of factor to use: I(percent) or I(count)."
                                             type: str
                                             returned: Always
                         asm_threshold:
-                            description: >
-                                ASM shows the number of addresses forecast to be used I(forecast)periodI( days in the future, if it is greater than )asmI(threshold)percentI( * )dhcpI(total) (see I(dhcp)utilization_) then the subnet is flagged.
+                            description:
+                                - "ASM shows the number of addresses forecast to be used I(forecast_period) days in the future, if it is greater than I(asm_threshold_percent) * I(dhcp_total) (see I(dhcp_utilization)) then the subnet is flagged."
                             type: dict
                             returned: Always
                             contains:
                                 action:
-                                    description: >
-                                        The inheritance setting for a field.
-                                        
-                                        Valid values are:
-                                        * I(inherit): Use the inherited value.
-                                        * I(override): Use the value set in the object.
-                                        
-                                        Defaults to I(inherit).
+                                    description:
+                                        - "The inheritance setting for a field."
+                                        - "Valid values are:"
+                                        - "* I(inherit): Use the inherited value."
+                                        - "* I(override): Use the value set in the object."
+                                        - "Defaults to I(inherit)."
                                     type: str
                                     returned: Always
                                 display_name:
-                                    description: >
-                                        The human-readable display name for the object referred to by I(source).
+                                    description:
+                                        - "The human-readable display name for the object referred to by I(source)."
                                     type: str
                                     returned: Always
                                 source:
-                                    description: >
-                                        The resource identifier.
+                                    description:
+                                        - "The resource identifier."
                                     type: str
                                     returned: Always
                                 value:
-                                    description: >
-                                        The inherited value.
+                                    description:
+                                        - "The inherited value."
                                     type: int
                                     returned: Always
                         forecast_period:
-                            description: >
-                                The forecast period in days.
+                            description:
+                                - "The forecast period in days."
                             type: dict
                             returned: Always
                             contains:
                                 action:
-                                    description: >
-                                        The inheritance setting for a field.
-                                        
-                                        Valid values are:
-                                        * I(inherit): Use the inherited value.
-                                        * I(override): Use the value set in the object.
-                                        
-                                        Defaults to I(inherit).
+                                    description:
+                                        - "The inheritance setting for a field."
+                                        - "Valid values are:"
+                                        - "* I(inherit): Use the inherited value."
+                                        - "* I(override): Use the value set in the object."
+                                        - "Defaults to I(inherit)."
                                     type: str
                                     returned: Always
                                 display_name:
-                                    description: >
-                                        The human-readable display name for the object referred to by I(source).
+                                    description:
+                                        - "The human-readable display name for the object referred to by I(source)."
                                     type: str
                                     returned: Always
                                 source:
-                                    description: >
-                                        The resource identifier.
+                                    description:
+                                        - "The resource identifier."
                                     type: str
                                     returned: Always
                                 value:
-                                    description: >
-                                        The inherited value.
+                                    description:
+                                        - "The inherited value."
                                     type: int
                                     returned: Always
                         history:
-                            description: >
-                                The minimum amount of history needed before ASM can run on this subnet.
+                            description:
+                                - "The minimum amount of history needed before ASM can run on this subnet."
                             type: dict
                             returned: Always
                             contains:
                                 action:
-                                    description: >
-                                        The inheritance setting for a field.
-                                        
-                                        Valid values are:
-                                        * I(inherit): Use the inherited value.
-                                        * I(override): Use the value set in the object.
-                                        
-                                        Defaults to I(inherit).
+                                    description:
+                                        - "The inheritance setting for a field."
+                                        - "Valid values are:"
+                                        - "* I(inherit): Use the inherited value."
+                                        - "* I(override): Use the value set in the object."
+                                        - "Defaults to I(inherit)."
                                     type: str
                                     returned: Always
                                 display_name:
-                                    description: >
-                                        The human-readable display name for the object referred to by I(source).
+                                    description:
+                                        - "The human-readable display name for the object referred to by I(source)."
                                     type: str
                                     returned: Always
                                 source:
-                                    description: >
-                                        The resource identifier.
+                                    description:
+                                        - "The resource identifier."
                                     type: str
                                     returned: Always
                                 value:
-                                    description: >
-                                        The inherited value.
+                                    description:
+                                        - "The inherited value."
                                     type: int
                                     returned: Always
                         min_total:
-                            description: >
-                                The minimum size of range needed for ASM to run on this subnet.
+                            description:
+                                - "The minimum size of range needed for ASM to run on this subnet."
                             type: dict
                             returned: Always
                             contains:
                                 action:
-                                    description: >
-                                        The inheritance setting for a field.
-                                        
-                                        Valid values are:
-                                        * I(inherit): Use the inherited value.
-                                        * I(override): Use the value set in the object.
-                                        
-                                        Defaults to I(inherit).
+                                    description:
+                                        - "The inheritance setting for a field."
+                                        - "Valid values are:"
+                                        - "* I(inherit): Use the inherited value."
+                                        - "* I(override): Use the value set in the object."
+                                        - "Defaults to I(inherit)."
                                     type: str
                                     returned: Always
                                 display_name:
-                                    description: >
-                                        The human-readable display name for the object referred to by I(source).
+                                    description:
+                                        - "The human-readable display name for the object referred to by I(source)."
                                     type: str
                                     returned: Always
                                 source:
-                                    description: >
-                                        The resource identifier.
+                                    description:
+                                        - "The resource identifier."
                                     type: str
                                     returned: Always
                                 value:
-                                    description: >
-                                        The inherited value.
+                                    description:
+                                        - "The inherited value."
                                     type: int
                                     returned: Always
                         min_unused:
-                            description: >
-                                The minimum percentage of addresses that must be available outside of the DHCP ranges and fixed addresses when making a suggested change.
+                            description:
+                                - "The minimum percentage of addresses that must be available outside of the DHCP ranges and fixed addresses when making a suggested change."
                             type: dict
                             returned: Always
                             contains:
                                 action:
-                                    description: >
-                                        The inheritance setting for a field.
-                                        
-                                        Valid values are:
-                                        * I(inherit): Use the inherited value.
-                                        * I(override): Use the value set in the object.
-                                        
-                                        Defaults to I(inherit).
+                                    description:
+                                        - "The inheritance setting for a field."
+                                        - "Valid values are:"
+                                        - "* I(inherit): Use the inherited value."
+                                        - "* I(override): Use the value set in the object."
+                                        - "Defaults to I(inherit)."
                                     type: str
                                     returned: Always
                                 display_name:
-                                    description: >
-                                        The human-readable display name for the object referred to by I(source).
+                                    description:
+                                        - "The human-readable display name for the object referred to by I(source)."
                                     type: str
                                     returned: Always
                                 source:
-                                    description: >
-                                        The resource identifier.
+                                    description:
+                                        - "The resource identifier."
                                     type: str
                                     returned: Always
                                 value:
-                                    description: >
-                                        The inherited value.
+                                    description:
+                                        - "The inherited value."
                                     type: int
                                     returned: Always
                 ddns_client_update:
-                    description: >
-                        The inheritance configuration for I(ddns)clientI(update) field from I(IPSpace) object.
+                    description:
+                        - "The inheritance configuration for I(ddns_client_update) field from I(IPSpace) object."
                     type: dict
                     returned: Always
                     contains:
                         action:
-                            description: >
-                                The inheritance setting for a field.
-                                
-                                Valid values are:
-                                * I(inherit): Use the inherited value.
-                                * I(override): Use the value set in the object.
-                                
-                                Defaults to I(inherit).
+                            description:
+                                - "The inheritance setting for a field."
+                                - "Valid values are:"
+                                - "* I(inherit): Use the inherited value."
+                                - "* I(override): Use the value set in the object."
+                                - "Defaults to I(inherit)."
                             type: str
                             returned: Always
                         display_name:
-                            description: >
-                                The human-readable display name for the object referred to by I(source).
+                            description:
+                                - "The human-readable display name for the object referred to by I(source)."
                             type: str
                             returned: Always
                         source:
-                            description: >
-                                The resource identifier.
+                            description:
+                                - "The resource identifier."
                             type: str
                             returned: Always
                         value:
-                            description: >
-                                The inherited value.
+                            description:
+                                - "The inherited value."
                             type: str
                             returned: Always
                 ddns_conflict_resolution_mode:
-                    description: >
-                        The inheritance configuration for I(ddns)conflictI(resolution)modeI( field from )IPSpace_ object.
+                    description:
+                        - "The inheritance configuration for I(ddns_conflict_resolution_mode) field from I(IPSpace) object."
                     type: dict
                     returned: Always
                     contains:
                         action:
-                            description: >
-                                The inheritance setting for a field.
-                                
-                                Valid values are:
-                                * I(inherit): Use the inherited value.
-                                * I(override): Use the value set in the object.
-                                
-                                Defaults to I(inherit).
+                            description:
+                                - "The inheritance setting for a field."
+                                - "Valid values are:"
+                                - "* I(inherit): Use the inherited value."
+                                - "* I(override): Use the value set in the object."
+                                - "Defaults to I(inherit)."
                             type: str
                             returned: Always
                         display_name:
-                            description: >
-                                The human-readable display name for the object referred to by I(source).
+                            description:
+                                - "The human-readable display name for the object referred to by I(source)."
                             type: str
                             returned: Always
                         source:
-                            description: >
-                                The resource identifier.
+                            description:
+                                - "The resource identifier."
                             type: str
                             returned: Always
                         value:
-                            description: >
-                                The inherited value.
+                            description:
+                                - "The inherited value."
                             type: str
                             returned: Always
                 ddns_enabled:
-                    description: >
-                        The inheritance configuration for I(ddns)enabled_ field. Only action allowed is 'inherit'.
+                    description:
+                        - "The inheritance configuration for I(ddns_enabled) field. Only action allowed is &#x27;inherit&#x27;."
                     type: dict
                     returned: Always
                     contains:
                         action:
-                            description: >
-                                The inheritance setting for a field.
-                                
-                                Valid values are:
-                                * I(inherit): Use the inherited value.
-                                * I(override): Use the value set in the object.
-                                
-                                Defaults to I(inherit).
+                            description:
+                                - "The inheritance setting for a field."
+                                - "Valid values are:"
+                                - "* I(inherit): Use the inherited value."
+                                - "* I(override): Use the value set in the object."
+                                - "Defaults to I(inherit)."
                             type: str
                             returned: Always
                         display_name:
-                            description: >
-                                The human-readable display name for the object referred to by I(source).
+                            description:
+                                - "The human-readable display name for the object referred to by I(source)."
                             type: str
                             returned: Always
                         source:
-                            description: >
-                                The resource identifier.
+                            description:
+                                - "The resource identifier."
                             type: str
                             returned: Always
                         value:
-                            description: >
-                                The inherited value.
+                            description:
+                                - "The inherited value."
                             type: bool
                             returned: Always
                 ddns_hostname_block:
-                    description: >
-                        The inheritance configuration for I(ddns)generateI(name) and I(ddns)generatedI(prefix) fields from I(IPSpace) object.
+                    description:
+                        - "The inheritance configuration for I(ddns_generate_name) and I(ddns_generated_prefix) fields from I(IPSpace) object."
                     type: dict
                     returned: Always
                     contains:
                         action:
-                            description: >
-                                The inheritance setting.
-                                
-                                Valid values are:
-                                * I(inherit): Use the inherited value.
-                                * I(override): Use the value set in the object.
-                                
-                                Defaults to I(inherit).
+                            description:
+                                - "The inheritance setting."
+                                - "Valid values are:"
+                                - "* I(inherit): Use the inherited value."
+                                - "* I(override): Use the value set in the object."
+                                - "Defaults to I(inherit)."
                             type: str
                             returned: Always
                         display_name:
-                            description: >
-                                The human-readable display name for the object referred to by I(source).
+                            description:
+                                - "The human-readable display name for the object referred to by I(source)."
                             type: str
                             returned: Always
                         source:
-                            description: >
-                                The resource identifier.
+                            description:
+                                - "The resource identifier."
                             type: str
                             returned: Always
                         value:
-                            description: >
-                                The inherited value.
+                            description:
+                                - "The inherited value."
                             type: dict
                             returned: Always
                             contains:
                                 ddns_generate_name:
-                                    description: >
-                                        Indicates if DDNS should generate a hostname when not supplied by the client.
+                                    description:
+                                        - "Indicates if DDNS should generate a hostname when not supplied by the client."
                                     type: bool
                                     returned: Always
                                 ddns_generated_prefix:
-                                    description: >
-                                        The prefix used in the generation of an FQDN.
+                                    description:
+                                        - "The prefix used in the generation of an FQDN."
                                     type: str
                                     returned: Always
                 ddns_ttl_percent:
-                    description: >
-                        The inheritance configuration for I(ddns)ttlI(percent) field from I(IPSpace) object.
+                    description:
+                        - "The inheritance configuration for I(ddns_ttl_percent) field from I(IPSpace) object."
                     type: dict
                     returned: Always
                     contains:
                         action:
-                            description: >
-                                The inheritance setting for a field.
-                                
-                                Valid values are:
-                                * I(inherit): Use the inherited value.
-                                * I(override): Use the value set in the object.
-                                
-                                Defaults to I(inherit).
+                            description:
+                                - "The inheritance setting for a field."
+                                - "Valid values are:"
+                                - "* I(inherit): Use the inherited value."
+                                - "* I(override): Use the value set in the object."
+                                - "Defaults to I(inherit)."
                             type: str
                             returned: Always
                         display_name:
-                            description: >
-                                The human-readable display name for the object referred to by I(source).
+                            description:
+                                - "The human-readable display name for the object referred to by I(source)."
                             type: str
                             returned: Always
                         source:
-                            description: >
-                                The resource identifier.
+                            description:
+                                - "The resource identifier."
                             type: str
                             returned: Always
                         value:
-                            description: >
-                                The inherited value.
+                            description:
+                                - "The inherited value."
                             type: float
                             returned: Always
                 ddns_update_block:
-                    description: >
-                        The inheritance configuration for I(ddns)sendI(updates) and I(ddns)domainI( fields from )IPSpace_ object.
+                    description:
+                        - "The inheritance configuration for I(ddns_send_updates) and I(ddns_domain) fields from I(IPSpace) object."
                     type: dict
                     returned: Always
                     contains:
                         action:
-                            description: >
-                                The inheritance setting.
-                                
-                                Valid values are:
-                                * I(inherit): Use the inherited value.
-                                * I(override): Use the value set in the object.
-                                
-                                Defaults to I(inherit).
+                            description:
+                                - "The inheritance setting."
+                                - "Valid values are:"
+                                - "* I(inherit): Use the inherited value."
+                                - "* I(override): Use the value set in the object."
+                                - "Defaults to I(inherit)."
                             type: str
                             returned: Always
                         display_name:
-                            description: >
-                                The human-readable display name for the object referred to by I(source).
+                            description:
+                                - "The human-readable display name for the object referred to by I(source)."
                             type: str
                             returned: Always
                         source:
-                            description: >
-                                The resource identifier.
+                            description:
+                                - "The resource identifier."
                             type: str
                             returned: Always
                         value:
-                            description: >
-                                The inherited value.
+                            description:
+                                - "The inherited value."
                             type: dict
                             returned: Always
                             contains:
                                 ddns_domain:
-                                    description: >
-                                        The domain name for DDNS.
+                                    description:
+                                        - "The domain name for DDNS."
                                     type: str
                                     returned: Always
                                 ddns_send_updates:
-                                    description: >
-                                        Determines if DDNS updates are enabled at this level.
+                                    description:
+                                        - "Determines if DDNS updates are enabled at this level."
                                     type: bool
                                     returned: Always
                 ddns_update_on_renew:
-                    description: >
-                        The inheritance configuration for I(ddns)updateI(on)renewI( field from )IPSpace_ object.
+                    description:
+                        - "The inheritance configuration for I(ddns_update_on_renew) field from I(IPSpace) object."
                     type: dict
                     returned: Always
                     contains:
                         action:
-                            description: >
-                                The inheritance setting for a field.
-                                
-                                Valid values are:
-                                * I(inherit): Use the inherited value.
-                                * I(override): Use the value set in the object.
-                                
-                                Defaults to I(inherit).
+                            description:
+                                - "The inheritance setting for a field."
+                                - "Valid values are:"
+                                - "* I(inherit): Use the inherited value."
+                                - "* I(override): Use the value set in the object."
+                                - "Defaults to I(inherit)."
                             type: str
                             returned: Always
                         display_name:
-                            description: >
-                                The human-readable display name for the object referred to by I(source).
+                            description:
+                                - "The human-readable display name for the object referred to by I(source)."
                             type: str
                             returned: Always
                         source:
-                            description: >
-                                The resource identifier.
+                            description:
+                                - "The resource identifier."
                             type: str
                             returned: Always
                         value:
-                            description: >
-                                The inherited value.
+                            description:
+                                - "The inherited value."
                             type: bool
                             returned: Always
                 ddns_use_conflict_resolution:
-                    description: >
-                        The inheritance configuration for I(ddns)useI(conflict)resolutionI( field from )IPSpace_ object.
+                    description:
+                        - "The inheritance configuration for I(ddns_use_conflict_resolution) field from I(IPSpace) object."
                     type: dict
                     returned: Always
                     contains:
                         action:
-                            description: >
-                                The inheritance setting for a field.
-                                
-                                Valid values are:
-                                * I(inherit): Use the inherited value.
-                                * I(override): Use the value set in the object.
-                                
-                                Defaults to I(inherit).
+                            description:
+                                - "The inheritance setting for a field."
+                                - "Valid values are:"
+                                - "* I(inherit): Use the inherited value."
+                                - "* I(override): Use the value set in the object."
+                                - "Defaults to I(inherit)."
                             type: str
                             returned: Always
                         display_name:
-                            description: >
-                                The human-readable display name for the object referred to by I(source).
+                            description:
+                                - "The human-readable display name for the object referred to by I(source)."
                             type: str
                             returned: Always
                         source:
-                            description: >
-                                The resource identifier.
+                            description:
+                                - "The resource identifier."
                             type: str
                             returned: Always
                         value:
-                            description: >
-                                The inherited value.
+                            description:
+                                - "The inherited value."
                             type: bool
                             returned: Always
                 dhcp_config:
-                    description: >
-                        The inheritance configuration for I(dhcp)config_ field.
+                    description:
+                        - "The inheritance configuration for I(dhcp_config) field."
                     type: dict
                     returned: Always
                     contains:
                         abandoned_reclaim_time:
-                            description: >
-                                The inheritance configuration for I(abandoned)reclaimI(time) field from I(DHCPConfig) object.
+                            description:
+                                - "The inheritance configuration for I(abandoned_reclaim_time) field from I(DHCPConfig) object."
                             type: dict
                             returned: Always
                             contains:
                                 action:
-                                    description: >
-                                        The inheritance setting for a field.
-                                        
-                                        Valid values are:
-                                        * I(inherit): Use the inherited value.
-                                        * I(override): Use the value set in the object.
-                                        
-                                        Defaults to I(inherit).
+                                    description:
+                                        - "The inheritance setting for a field."
+                                        - "Valid values are:"
+                                        - "* I(inherit): Use the inherited value."
+                                        - "* I(override): Use the value set in the object."
+                                        - "Defaults to I(inherit)."
                                     type: str
                                     returned: Always
                                 display_name:
-                                    description: >
-                                        The human-readable display name for the object referred to by I(source).
+                                    description:
+                                        - "The human-readable display name for the object referred to by I(source)."
                                     type: str
                                     returned: Always
                                 source:
-                                    description: >
-                                        The resource identifier.
+                                    description:
+                                        - "The resource identifier."
                                     type: str
                                     returned: Always
                                 value:
-                                    description: >
-                                        The inherited value.
+                                    description:
+                                        - "The inherited value."
                                     type: int
                                     returned: Always
                         abandoned_reclaim_time_v6:
-                            description: >
-                                The inheritance configuration for I(abandoned)reclaimI(time)v6I( field from )DHCPConfig_ object.
+                            description:
+                                - "The inheritance configuration for I(abandoned_reclaim_time_v6) field from I(DHCPConfig) object."
                             type: dict
                             returned: Always
                             contains:
                                 action:
-                                    description: >
-                                        The inheritance setting for a field.
-                                        
-                                        Valid values are:
-                                        * I(inherit): Use the inherited value.
-                                        * I(override): Use the value set in the object.
-                                        
-                                        Defaults to I(inherit).
+                                    description:
+                                        - "The inheritance setting for a field."
+                                        - "Valid values are:"
+                                        - "* I(inherit): Use the inherited value."
+                                        - "* I(override): Use the value set in the object."
+                                        - "Defaults to I(inherit)."
                                     type: str
                                     returned: Always
                                 display_name:
-                                    description: >
-                                        The human-readable display name for the object referred to by I(source).
+                                    description:
+                                        - "The human-readable display name for the object referred to by I(source)."
                                     type: str
                                     returned: Always
                                 source:
-                                    description: >
-                                        The resource identifier.
+                                    description:
+                                        - "The resource identifier."
                                     type: str
                                     returned: Always
                                 value:
-                                    description: >
-                                        The inherited value.
+                                    description:
+                                        - "The inherited value."
                                     type: int
                                     returned: Always
                         allow_unknown:
-                            description: >
-                                The inheritance configuration for I(allow)unknownI( field from )DHCPConfig_ object.
+                            description:
+                                - "The inheritance configuration for I(allow_unknown) field from I(DHCPConfig) object."
                             type: dict
                             returned: Always
                             contains:
                                 action:
-                                    description: >
-                                        The inheritance setting for a field.
-                                        
-                                        Valid values are:
-                                        * I(inherit): Use the inherited value.
-                                        * I(override): Use the value set in the object.
-                                        
-                                        Defaults to I(inherit).
+                                    description:
+                                        - "The inheritance setting for a field."
+                                        - "Valid values are:"
+                                        - "* I(inherit): Use the inherited value."
+                                        - "* I(override): Use the value set in the object."
+                                        - "Defaults to I(inherit)."
                                     type: str
                                     returned: Always
                                 display_name:
-                                    description: >
-                                        The human-readable display name for the object referred to by I(source).
+                                    description:
+                                        - "The human-readable display name for the object referred to by I(source)."
                                     type: str
                                     returned: Always
                                 source:
-                                    description: >
-                                        The resource identifier.
+                                    description:
+                                        - "The resource identifier."
                                     type: str
                                     returned: Always
                                 value:
-                                    description: >
-                                        The inherited value.
+                                    description:
+                                        - "The inherited value."
                                     type: bool
                                     returned: Always
                         allow_unknown_v6:
-                            description: >
-                                The inheritance configuration for I(allow)unknownI(v6) field from I(DHCPConfig) object.
+                            description:
+                                - "The inheritance configuration for I(allow_unknown_v6) field from I(DHCPConfig) object."
                             type: dict
                             returned: Always
                             contains:
                                 action:
-                                    description: >
-                                        The inheritance setting for a field.
-                                        
-                                        Valid values are:
-                                        * I(inherit): Use the inherited value.
-                                        * I(override): Use the value set in the object.
-                                        
-                                        Defaults to I(inherit).
+                                    description:
+                                        - "The inheritance setting for a field."
+                                        - "Valid values are:"
+                                        - "* I(inherit): Use the inherited value."
+                                        - "* I(override): Use the value set in the object."
+                                        - "Defaults to I(inherit)."
                                     type: str
                                     returned: Always
                                 display_name:
-                                    description: >
-                                        The human-readable display name for the object referred to by I(source).
+                                    description:
+                                        - "The human-readable display name for the object referred to by I(source)."
                                     type: str
                                     returned: Always
                                 source:
-                                    description: >
-                                        The resource identifier.
+                                    description:
+                                        - "The resource identifier."
                                     type: str
                                     returned: Always
                                 value:
-                                    description: >
-                                        The inherited value.
+                                    description:
+                                        - "The inherited value."
                                     type: bool
                                     returned: Always
                         echo_client_id:
-                            description: >
-                                The inheritance configuration for I(echo)clientI(id) field from I(DHCPConfig) object.
+                            description:
+                                - "The inheritance configuration for I(echo_client_id) field from I(DHCPConfig) object."
                             type: dict
                             returned: Always
                             contains:
                                 action:
-                                    description: >
-                                        The inheritance setting for a field.
-                                        
-                                        Valid values are:
-                                        * I(inherit): Use the inherited value.
-                                        * I(override): Use the value set in the object.
-                                        
-                                        Defaults to I(inherit).
+                                    description:
+                                        - "The inheritance setting for a field."
+                                        - "Valid values are:"
+                                        - "* I(inherit): Use the inherited value."
+                                        - "* I(override): Use the value set in the object."
+                                        - "Defaults to I(inherit)."
                                     type: str
                                     returned: Always
                                 display_name:
-                                    description: >
-                                        The human-readable display name for the object referred to by I(source).
+                                    description:
+                                        - "The human-readable display name for the object referred to by I(source)."
                                     type: str
                                     returned: Always
                                 source:
-                                    description: >
-                                        The resource identifier.
+                                    description:
+                                        - "The resource identifier."
                                     type: str
                                     returned: Always
                                 value:
-                                    description: >
-                                        The inherited value.
+                                    description:
+                                        - "The inherited value."
                                     type: bool
                                     returned: Always
                         filters:
-                            description: >
-                                The inheritance configuration for filters field from I(DHCPConfig) object.
+                            description:
+                                - "The inheritance configuration for filters field from I(DHCPConfig) object."
                             type: dict
                             returned: Always
                             contains:
                                 action:
-                                    description: >
-                                        The inheritance setting.
-                                        
-                                        Valid values are:
-                                        * I(inherit): Use the inherited value.
-                                        * I(override): Use the value set in the object.
-                                        
-                                        Defaults to I(inherit).
+                                    description:
+                                        - "The inheritance setting."
+                                        - "Valid values are:"
+                                        - "* I(inherit): Use the inherited value."
+                                        - "* I(override): Use the value set in the object."
+                                        - "Defaults to I(inherit)."
                                     type: str
                                     returned: Always
                                 display_name:
-                                    description: >
-                                        The human-readable display name for the object referred to by I(source).
+                                    description:
+                                        - "The human-readable display name for the object referred to by I(source)."
                                     type: str
                                     returned: Always
                                 source:
-                                    description: >
-                                        The resource identifier.
+                                    description:
+                                        - "The resource identifier."
                                     type: str
                                     returned: Always
                                 value:
-                                    description: >
-                                        The resource identifier.
+                                    description:
+                                        - "The resource identifier."
                                     type: list
                                     returned: Always
                         filters_v6:
-                            description: >
-                                The inheritance configuration for I(filters)v6I( field from )DHCPConfig_ object.
+                            description:
+                                - "The inheritance configuration for I(filters_v6) field from I(DHCPConfig) object."
                             type: dict
                             returned: Always
                             contains:
                                 action:
-                                    description: >
-                                        The inheritance setting.
-                                        
-                                        Valid values are:
-                                        * I(inherit): Use the inherited value.
-                                        * I(override): Use the value set in the object.
-                                        
-                                        Defaults to I(inherit).
+                                    description:
+                                        - "The inheritance setting."
+                                        - "Valid values are:"
+                                        - "* I(inherit): Use the inherited value."
+                                        - "* I(override): Use the value set in the object."
+                                        - "Defaults to I(inherit)."
                                     type: str
                                     returned: Always
                                 display_name:
-                                    description: >
-                                        The human-readable display name for the object referred to by I(source).
+                                    description:
+                                        - "The human-readable display name for the object referred to by I(source)."
                                     type: str
                                     returned: Always
                                 source:
-                                    description: >
-                                        The resource identifier.
+                                    description:
+                                        - "The resource identifier."
                                     type: str
                                     returned: Always
                                 value:
-                                    description: >
-                                        The resource identifier.
+                                    description:
+                                        - "The resource identifier."
                                     type: list
                                     returned: Always
                         ignore_client_uid:
-                            description: >
-                                The inheritance configuration for I(ignore)clientI(uid) field from I(DHCPConfig) object.
+                            description:
+                                - "The inheritance configuration for I(ignore_client_uid) field from I(DHCPConfig) object."
                             type: dict
                             returned: Always
                             contains:
                                 action:
-                                    description: >
-                                        The inheritance setting for a field.
-                                        
-                                        Valid values are:
-                                        * I(inherit): Use the inherited value.
-                                        * I(override): Use the value set in the object.
-                                        
-                                        Defaults to I(inherit).
+                                    description:
+                                        - "The inheritance setting for a field."
+                                        - "Valid values are:"
+                                        - "* I(inherit): Use the inherited value."
+                                        - "* I(override): Use the value set in the object."
+                                        - "Defaults to I(inherit)."
                                     type: str
                                     returned: Always
                                 display_name:
-                                    description: >
-                                        The human-readable display name for the object referred to by I(source).
+                                    description:
+                                        - "The human-readable display name for the object referred to by I(source)."
                                     type: str
                                     returned: Always
                                 source:
-                                    description: >
-                                        The resource identifier.
+                                    description:
+                                        - "The resource identifier."
                                     type: str
                                     returned: Always
                                 value:
-                                    description: >
-                                        The inherited value.
+                                    description:
+                                        - "The inherited value."
                                     type: bool
                                     returned: Always
                         ignore_list:
-                            description: >
-                                The inheritance configuration for I(ignore)listI( field from )DHCPConfig_ object.
+                            description:
+                                - "The inheritance configuration for I(ignore_list) field from I(DHCPConfig) object."
                             type: dict
                             returned: Always
                             contains:
                                 action:
-                                    description: >
-                                        The inheritance setting.
-                                        
-                                        Valid values are:
-                                        * I(inherit): Use the inherited value.
-                                        * I(override): Use the value set in the object.
-                                        
-                                        Defaults to I(inherit).
+                                    description:
+                                        - "The inheritance setting."
+                                        - "Valid values are:"
+                                        - "* I(inherit): Use the inherited value."
+                                        - "* I(override): Use the value set in the object."
+                                        - "Defaults to I(inherit)."
                                     type: str
                                     returned: Always
                                 display_name:
-                                    description: >
-                                        The human-readable display name for the object referred to by I(source).
+                                    description:
+                                        - "The human-readable display name for the object referred to by I(source)."
                                     type: str
                                     returned: Always
                                 source:
-                                    description: >
-                                        The resource identifier.
+                                    description:
+                                        - "The resource identifier."
                                     type: str
                                     returned: Always
                                 value:
-                                    description: >
-                                        The inherited value.
+                                    description:
+                                        - "The inherited value."
                                     type: list
                                     returned: Always
                                     elements: dict
                                     contains:
                                         type:
-                                            description: >
-                                                Type of ignore matching: client to ignore by client identifier (client hex or client text) or hardware to ignore by hardware identifier (MAC address). It can have one of the following values:
-                                                * I(client)hex_,
-                                                * I(client)text_,
-                                                * I(hardware).
+                                            description:
+                                                - "Type of ignore matching: client to ignore by client identifier (client hex or client text) or hardware to ignore by hardware identifier (MAC address). It can have one of the following values:"
+                                                - "* I(client_hex),"
+                                                - "* I(client_text),"
+                                                - "* I(hardware)."
                                             type: str
                                             returned: Always
                                         value:
-                                            description: >
-                                                Value to match.
+                                            description:
+                                                - "Value to match."
                                             type: str
                                             returned: Always
                         lease_time:
-                            description: >
-                                The inheritance configuration for I(lease)timeI( field from )DHCPConfig_ object.
+                            description:
+                                - "The inheritance configuration for I(lease_time) field from I(DHCPConfig) object."
                             type: dict
                             returned: Always
                             contains:
                                 action:
-                                    description: >
-                                        The inheritance setting for a field.
-                                        
-                                        Valid values are:
-                                        * I(inherit): Use the inherited value.
-                                        * I(override): Use the value set in the object.
-                                        
-                                        Defaults to I(inherit).
+                                    description:
+                                        - "The inheritance setting for a field."
+                                        - "Valid values are:"
+                                        - "* I(inherit): Use the inherited value."
+                                        - "* I(override): Use the value set in the object."
+                                        - "Defaults to I(inherit)."
                                     type: str
                                     returned: Always
                                 display_name:
-                                    description: >
-                                        The human-readable display name for the object referred to by I(source).
+                                    description:
+                                        - "The human-readable display name for the object referred to by I(source)."
                                     type: str
                                     returned: Always
                                 source:
-                                    description: >
-                                        The resource identifier.
+                                    description:
+                                        - "The resource identifier."
                                     type: str
                                     returned: Always
                                 value:
-                                    description: >
-                                        The inherited value.
+                                    description:
+                                        - "The inherited value."
                                     type: int
                                     returned: Always
                         lease_time_v6:
-                            description: >
-                                The inheritance configuration for I(lease)timeI(v6) field from I(DHCPConfig) object.
+                            description:
+                                - "The inheritance configuration for I(lease_time_v6) field from I(DHCPConfig) object."
                             type: dict
                             returned: Always
                             contains:
                                 action:
-                                    description: >
-                                        The inheritance setting for a field.
-                                        
-                                        Valid values are:
-                                        * I(inherit): Use the inherited value.
-                                        * I(override): Use the value set in the object.
-                                        
-                                        Defaults to I(inherit).
+                                    description:
+                                        - "The inheritance setting for a field."
+                                        - "Valid values are:"
+                                        - "* I(inherit): Use the inherited value."
+                                        - "* I(override): Use the value set in the object."
+                                        - "Defaults to I(inherit)."
                                     type: str
                                     returned: Always
                                 display_name:
-                                    description: >
-                                        The human-readable display name for the object referred to by I(source).
+                                    description:
+                                        - "The human-readable display name for the object referred to by I(source)."
                                     type: str
                                     returned: Always
                                 source:
-                                    description: >
-                                        The resource identifier.
+                                    description:
+                                        - "The resource identifier."
                                     type: str
                                     returned: Always
                                 value:
-                                    description: >
-                                        The inherited value.
+                                    description:
+                                        - "The inherited value."
                                     type: int
                                     returned: Always
                 dhcp_options:
-                    description: >
-                        The inheritance configuration for I(dhcp)options_ field.
+                    description:
+                        - "The inheritance configuration for I(dhcp_options) field."
                     type: dict
                     returned: Always
                     contains:
                         action:
-                            description: >
-                                The inheritance setting.
-                                
-                                Valid values are:
-                                * I(inherit): Use the inherited value.
-                                * I(block): Don't use the inherited value.
-                                
-                                Defaults to I(inherit).
+                            description:
+                                - "The inheritance setting."
+                                - "Valid values are:"
+                                - "* I(inherit): Use the inherited value."
+                                - "* I(block): Don&#x27;t use the inherited value."
+                                - "Defaults to I(inherit)."
                             type: str
                             returned: Always
                         value:
-                            description: >
-                                The inherited DHCP option values.
+                            description:
+                                - "The inherited DHCP option values."
                             type: list
                             returned: Always
                             elements: dict
                             contains:
                                 action:
-                                    description: >
-                                        The inheritance setting.
-                                        
-                                        Valid values are:
-                                        * I(inherit): Use the inherited value.
-                                        * I(block): Don't use the inherited value.
-                                        
-                                        Defaults to I(inherit).
+                                    description:
+                                        - "The inheritance setting."
+                                        - "Valid values are:"
+                                        - "* I(inherit): Use the inherited value."
+                                        - "* I(block): Don&#x27;t use the inherited value."
+                                        - "Defaults to I(inherit)."
                                     type: str
                                     returned: Always
                                 display_name:
-                                    description: >
-                                        The human-readable display name for the object referred to by I(source).
+                                    description:
+                                        - "The human-readable display name for the object referred to by I(source)."
                                     type: str
                                     returned: Always
                                 source:
-                                    description: >
-                                        The resource identifier.
+                                    description:
+                                        - "The resource identifier."
                                     type: str
                                     returned: Always
                                 value:
-                                    description: >
-                                        The inherited value for the DHCP option.
+                                    description:
+                                        - "The inherited value for the DHCP option."
                                     type: dict
                                     returned: Always
                                     contains:
                                         option:
-                                            description: >
-                                                Option inherited from the ancestor.
+                                            description:
+                                                - "Option inherited from the ancestor."
                                             type: dict
                                             returned: Always
                                             contains:
                                                 group:
-                                                    description: >
-                                                        The resource identifier.
+                                                    description:
+                                                        - "The resource identifier."
                                                     type: str
                                                     returned: Always
                                                 option_code:
-                                                    description: >
-                                                        The resource identifier.
+                                                    description:
+                                                        - "The resource identifier."
                                                     type: str
                                                     returned: Always
                                                 option_value:
-                                                    description: >
-                                                        The option value.
+                                                    description:
+                                                        - "The option value."
                                                     type: str
                                                     returned: Always
                                                 type:
-                                                    description: >
-                                                        The type of item.
-                                                        
-                                                        Valid values are:
-                                                        * I(group)
-                                                        * I(option)
+                                                    description:
+                                                        - "The type of item."
+                                                        - "Valid values are:"
+                                                        - "* I(group)"
+                                                        - "* I(option)"
                                                     type: str
                                                     returned: Always
                                         overriding_group:
-                                            description: >
-                                                The resource identifier.
+                                            description:
+                                                - "The resource identifier."
                                             type: str
                                             returned: Always
                 dhcp_options_v6:
-                    description: >
-                        The inheritance configuration for I(dhcp)optionsI(v6) field.
+                    description:
+                        - "The inheritance configuration for I(dhcp_options_v6) field."
                     type: dict
                     returned: Always
                     contains:
                         action:
-                            description: >
-                                The inheritance setting.
-                                
-                                Valid values are:
-                                * I(inherit): Use the inherited value.
-                                * I(block): Don't use the inherited value.
-                                
-                                Defaults to I(inherit).
+                            description:
+                                - "The inheritance setting."
+                                - "Valid values are:"
+                                - "* I(inherit): Use the inherited value."
+                                - "* I(block): Don&#x27;t use the inherited value."
+                                - "Defaults to I(inherit)."
                             type: str
                             returned: Always
                         value:
-                            description: >
-                                The inherited DHCP option values.
+                            description:
+                                - "The inherited DHCP option values."
                             type: list
                             returned: Always
                             elements: dict
                             contains:
                                 action:
-                                    description: >
-                                        The inheritance setting.
-                                        
-                                        Valid values are:
-                                        * I(inherit): Use the inherited value.
-                                        * I(block): Don't use the inherited value.
-                                        
-                                        Defaults to I(inherit).
+                                    description:
+                                        - "The inheritance setting."
+                                        - "Valid values are:"
+                                        - "* I(inherit): Use the inherited value."
+                                        - "* I(block): Don&#x27;t use the inherited value."
+                                        - "Defaults to I(inherit)."
                                     type: str
                                     returned: Always
                                 display_name:
-                                    description: >
-                                        The human-readable display name for the object referred to by I(source).
+                                    description:
+                                        - "The human-readable display name for the object referred to by I(source)."
                                     type: str
                                     returned: Always
                                 source:
-                                    description: >
-                                        The resource identifier.
+                                    description:
+                                        - "The resource identifier."
                                     type: str
                                     returned: Always
                                 value:
-                                    description: >
-                                        The inherited value for the DHCP option.
+                                    description:
+                                        - "The inherited value for the DHCP option."
                                     type: dict
                                     returned: Always
                                     contains:
                                         option:
-                                            description: >
-                                                Option inherited from the ancestor.
+                                            description:
+                                                - "Option inherited from the ancestor."
                                             type: dict
                                             returned: Always
                                             contains:
                                                 group:
-                                                    description: >
-                                                        The resource identifier.
+                                                    description:
+                                                        - "The resource identifier."
                                                     type: str
                                                     returned: Always
                                                 option_code:
-                                                    description: >
-                                                        The resource identifier.
+                                                    description:
+                                                        - "The resource identifier."
                                                     type: str
                                                     returned: Always
                                                 option_value:
-                                                    description: >
-                                                        The option value.
+                                                    description:
+                                                        - "The option value."
                                                     type: str
                                                     returned: Always
                                                 type:
-                                                    description: >
-                                                        The type of item.
-                                                        
-                                                        Valid values are:
-                                                        * I(group)
-                                                        * I(option)
+                                                    description:
+                                                        - "The type of item."
+                                                        - "Valid values are:"
+                                                        - "* I(group)"
+                                                        - "* I(option)"
                                                     type: str
                                                     returned: Always
                                         overriding_group:
-                                            description: >
-                                                The resource identifier.
+                                            description:
+                                                - "The resource identifier."
                                             type: str
                                             returned: Always
                 header_option_filename:
-                    description: >
-                        The inheritance configuration for I(header)optionI(filename) field.
+                    description:
+                        - "The inheritance configuration for I(header_option_filename) field."
                     type: dict
                     returned: Always
                     contains:
                         action:
-                            description: >
-                                The inheritance setting for a field.
-                                
-                                Valid values are:
-                                * I(inherit): Use the inherited value.
-                                * I(override): Use the value set in the object.
-                                
-                                Defaults to I(inherit).
+                            description:
+                                - "The inheritance setting for a field."
+                                - "Valid values are:"
+                                - "* I(inherit): Use the inherited value."
+                                - "* I(override): Use the value set in the object."
+                                - "Defaults to I(inherit)."
                             type: str
                             returned: Always
                         display_name:
-                            description: >
-                                The human-readable display name for the object referred to by I(source).
+                            description:
+                                - "The human-readable display name for the object referred to by I(source)."
                             type: str
                             returned: Always
                         source:
-                            description: >
-                                The resource identifier.
+                            description:
+                                - "The resource identifier."
                             type: str
                             returned: Always
                         value:
-                            description: >
-                                The inherited value.
+                            description:
+                                - "The inherited value."
                             type: str
                             returned: Always
                 header_option_server_address:
-                    description: >
-                        The inheritance configuration for I(header)optionI(server)address_ field.
+                    description:
+                        - "The inheritance configuration for I(header_option_server_address) field."
                     type: dict
                     returned: Always
                     contains:
                         action:
-                            description: >
-                                The inheritance setting for a field.
-                                
-                                Valid values are:
-                                * I(inherit): Use the inherited value.
-                                * I(override): Use the value set in the object.
-                                
-                                Defaults to I(inherit).
+                            description:
+                                - "The inheritance setting for a field."
+                                - "Valid values are:"
+                                - "* I(inherit): Use the inherited value."
+                                - "* I(override): Use the value set in the object."
+                                - "Defaults to I(inherit)."
                             type: str
                             returned: Always
                         display_name:
-                            description: >
-                                The human-readable display name for the object referred to by I(source).
+                            description:
+                                - "The human-readable display name for the object referred to by I(source)."
                             type: str
                             returned: Always
                         source:
-                            description: >
-                                The resource identifier.
+                            description:
+                                - "The resource identifier."
                             type: str
                             returned: Always
                         value:
-                            description: >
-                                The inherited value.
+                            description:
+                                - "The inherited value."
                             type: str
                             returned: Always
                 header_option_server_name:
-                    description: >
-                        The inheritance configuration for I(header)optionI(server)name_ field.
+                    description:
+                        - "The inheritance configuration for I(header_option_server_name) field."
                     type: dict
                     returned: Always
                     contains:
                         action:
-                            description: >
-                                The inheritance setting for a field.
-                                
-                                Valid values are:
-                                * I(inherit): Use the inherited value.
-                                * I(override): Use the value set in the object.
-                                
-                                Defaults to I(inherit).
+                            description:
+                                - "The inheritance setting for a field."
+                                - "Valid values are:"
+                                - "* I(inherit): Use the inherited value."
+                                - "* I(override): Use the value set in the object."
+                                - "Defaults to I(inherit)."
                             type: str
                             returned: Always
                         display_name:
-                            description: >
-                                The human-readable display name for the object referred to by I(source).
+                            description:
+                                - "The human-readable display name for the object referred to by I(source)."
                             type: str
                             returned: Always
                         source:
-                            description: >
-                                The resource identifier.
+                            description:
+                                - "The resource identifier."
                             type: str
                             returned: Always
                         value:
-                            description: >
-                                The inherited value.
+                            description:
+                                - "The inherited value."
                             type: str
                             returned: Always
                 hostname_rewrite_block:
-                    description: >
-                        The inheritance configuration for I(hostname)rewriteI(enabled), I(hostname)rewriteI(regex), and I(hostname)rewriteI(char) fields from I(IPSpace) object.
+                    description:
+                        - "The inheritance configuration for I(hostname_rewrite_enabled), I(hostname_rewrite_regex), and I(hostname_rewrite_char) fields from I(IPSpace) object."
                     type: dict
                     returned: Always
                     contains:
                         action:
-                            description: >
-                                The inheritance setting.
-                                
-                                Valid values are:
-                                * I(inherit): Use the inherited value.
-                                * I(override): Use the value set in the object.
-                                
-                                Defaults to I(inherit).
+                            description:
+                                - "The inheritance setting."
+                                - "Valid values are:"
+                                - "* I(inherit): Use the inherited value."
+                                - "* I(override): Use the value set in the object."
+                                - "Defaults to I(inherit)."
                             type: str
                             returned: Always
                         display_name:
-                            description: >
-                                The human-readable display name for the object referred to by I(source).
+                            description:
+                                - "The human-readable display name for the object referred to by I(source)."
                             type: str
                             returned: Always
                         source:
-                            description: >
-                                The resource identifier.
+                            description:
+                                - "The resource identifier."
                             type: str
                             returned: Always
                         value:
-                            description: >
-                                The inherited value.
+                            description:
+                                - "The inherited value."
                             type: dict
                             returned: Always
                             contains:
                                 hostname_rewrite_char:
-                                    description: >
-                                        The inheritance configuration for I(hostname)rewriteI(char) field.
+                                    description:
+                                        - "The inheritance configuration for I(hostname_rewrite_char) field."
                                     type: str
                                     returned: Always
                                 hostname_rewrite_enabled:
-                                    description: >
-                                        The inheritance configuration for I(hostname)rewriteI(enabled) field.
+                                    description:
+                                        - "The inheritance configuration for I(hostname_rewrite_enabled) field."
                                     type: bool
                                     returned: Always
                                 hostname_rewrite_regex:
-                                    description: >
-                                        The inheritance configuration for I(hostname)rewriteI(regex) field.
+                                    description:
+                                        - "The inheritance configuration for I(hostname_rewrite_regex) field."
                                     type: str
                                     returned: Always
                 vendor_specific_option_option_space:
-                    description: >
-                        The inheritance configuration for I(vendor)specificI(option)optionI(space) field.
+                    description:
+                        - "The inheritance configuration for I(vendor_specific_option_option_space) field."
                     type: dict
                     returned: Always
                     contains:
                         action:
-                            description: >
-                                The inheritance setting for a field.
-                                
-                                Valid values are:
-                                * I(inherit): Use the inherited value.
-                                * I(override): Use the value set in the object.
-                                
-                                Defaults to I(inherit).
+                            description:
+                                - "The inheritance setting for a field."
+                                - "Valid values are:"
+                                - "* I(inherit): Use the inherited value."
+                                - "* I(override): Use the value set in the object."
+                                - "Defaults to I(inherit)."
                             type: str
                             returned: Always
                         display_name:
-                            description: >
-                                The human-readable display name for the object referred to by I(source).
+                            description:
+                                - "The human-readable display name for the object referred to by I(source)."
                             type: str
                             returned: Always
                         source:
-                            description: >
-                                The resource identifier.
+                            description:
+                                - "The resource identifier."
                             type: str
                             returned: Always
                         value:
-                            description: >
-                                The resource identifier.
+                            description:
+                                - "The resource identifier."
                             type: str
                             returned: Always
         name:
-            description: >
-                The name of the IP space. Must contain 1 to 256 characters. Can include UTF-8.
+            description:
+                - "The name of the IP space. Must contain 1 to 256 characters. Can include UTF-8."
             type: str
             returned: Always
         tags:
-            description: >
-                The tags for the IP space in JSON format.
+            description:
+                - "The tags for the IP space in JSON format."
             type: dict
             returned: Always
         threshold:
-            description: >
-                The utilization threshold settings for the IP space.
+            description:
+                - "The utilization threshold settings for the IP space."
             type: dict
             returned: Always
             contains:
                 enabled:
-                    description: >
-                        Indicates whether the utilization threshold for IP addresses is enabled or not.
+                    description:
+                        - "Indicates whether the utilization threshold for IP addresses is enabled or not."
                     type: bool
                     returned: Always
                 high:
-                    description: >
-                        The high threshold value for the percentage of used IP addresses relative to the total IP addresses available in the scope of the object. Thresholds are inclusive in the comparison test.
+                    description:
+                        - "The high threshold value for the percentage of used IP addresses relative to the total IP addresses available in the scope of the object. Thresholds are inclusive in the comparison test."
                     type: int
                     returned: Always
                 low:
-                    description: >
-                        The low threshold value for the percentage of used IP addresses relative to the total IP addresses available in the scope of the object. Thresholds are inclusive in the comparison test.
+                    description:
+                        - "The low threshold value for the percentage of used IP addresses relative to the total IP addresses available in the scope of the object. Thresholds are inclusive in the comparison test."
                     type: int
                     returned: Always
         updated_at:
-            description: >
-                Time when the object has been updated. Equals to I(created)at_ if not updated after creation.
+            description:
+                - "Time when the object has been updated. Equals to I(created_at) if not updated after creation."
             type: str
             returned: Always
         utilization:
-            description: >
-                The utilization of IPV4 addresses in the IP space.
+            description:
+                - "The utilization of IPV4 addresses in the IP space."
             type: dict
             returned: Always
             contains:
                 abandon_utilization:
-                    description: >
-                        The percentage of abandoned IP addresses relative to the total IP addresses available in the scope of the object.
+                    description:
+                        - "The percentage of abandoned IP addresses relative to the total IP addresses available in the scope of the object."
                     type: int
                     returned: Always
                 abandoned:
-                    description: >
-                        The number of IP addresses in the scope of the object which are in the abandoned state (issued by a DHCP server and then declined by the client).
+                    description:
+                        - "The number of IP addresses in the scope of the object which are in the abandoned state (issued by a DHCP server and then declined by the client)."
                     type: str
                     returned: Always
                 dynamic:
-                    description: >
-                        The number of IP addresses handed out by DHCP in the scope of the object. This includes all leased addresses, fixed addresses that are defined but not currently leased and abandoned leases.
+                    description:
+                        - "The number of IP addresses handed out by DHCP in the scope of the object. This includes all leased addresses, fixed addresses that are defined but not currently leased and abandoned leases."
                     type: str
                     returned: Always
                 free:
-                    description: >
-                        The number of IP addresses available in the scope of the object.
+                    description:
+                        - "The number of IP addresses available in the scope of the object."
                     type: str
                     returned: Always
                 static:
-                    description: >
-                        The number of defined IP addresses such as reservations or DNS records. It can be computed as I(static) = I(used) - I(dynamic).
+                    description:
+                        - "The number of defined IP addresses such as reservations or DNS records. It can be computed as I(static) &#x3D; I(used) - I(dynamic)."
                     type: str
                     returned: Always
                 total:
-                    description: >
-                        The total number of IP addresses available in the scope of the object.
+                    description:
+                        - "The total number of IP addresses available in the scope of the object."
                     type: str
                     returned: Always
                 used:
-                    description: >
-                        The number of IP addresses used in the scope of the object.
+                    description:
+                        - "The number of IP addresses used in the scope of the object."
                     type: str
                     returned: Always
                 utilization:
-                    description: >
-                        The percentage of used IP addresses relative to the total IP addresses available in the scope of the object.
+                    description:
+                        - "The percentage of used IP addresses relative to the total IP addresses available in the scope of the object."
                     type: int
                     returned: Always
         utilization_v6:
-            description: >
-                The utilization of IPV6 addresses in the IP space.
+            description:
+                - "The utilization of IPV6 addresses in the IP space."
             type: dict
             returned: Always
             contains:
@@ -1794,8 +1699,8 @@ objects:
                     type: str
                     returned: Always
         vendor_specific_option_option_space:
-            description: >
-                The resource identifier.
+            description:
+                - "The resource identifier."
             type: str
             returned: Always
 """  # noqa: E501

--- a/tests/integration/requirements.txt
+++ b/tests/integration/requirements.txt
@@ -1,0 +1,1 @@
+bloxone-python-client @ git+https://github.com/infobloxopen/bloxone-python-client@fac16a90

--- a/tests/integration/targets/ipam_ip_space/tasks/main.yml
+++ b/tests/integration/targets/ipam_ip_space/tasks/main.yml
@@ -116,6 +116,50 @@
           - ip_space_info.objects[0].id == ip_space.id
           - ip_space_info.objects[0].tags.location == "site-1"
 
+    # Create an IP space with DHCP configuration value overridden
+    - name: "Create an IP space with DHCP configuration value overridden"
+      infoblox.bloxone.ipam_ip_space:
+          name: "{{ name }}"
+          dhcp_config:
+              lease_time: 3600
+          inheritance_sources:
+              dhcp_config:
+                  lease_time:
+                    action: override
+                  # The API currently requires all fields inside the inheritance config to be explicitly provided,
+                  # or it fails with error 'The value of an inheritance action field is not valid'.
+                  abandoned_reclaim_time:
+                    action: inherit
+                  abandoned_reclaim_time_v6:
+                    action: inherit
+                  allow_unknown:
+                      action: inherit
+                  allow_unknown_v6:
+                    action: inherit
+                  echo_client_id:
+                    action: inherit
+                  filters:
+                    action: inherit
+                  filters_v6:
+                    action: inherit
+                  ignore_client_uid:
+                    action: inherit
+                  ignore_list:
+                    action: inherit
+                  lease_time_v6:
+                    action: inherit
+    - name: Get information about the IP space
+      infoblox.bloxone.ipam_ip_space_info:
+        filters:
+          name: "{{ name }}"
+      register: ip_space_info
+    - assert:
+        that:
+          - ip_space is not failed
+          - ip_space_info.objects | length == 1
+          - ip_space_info.objects[0].dhcp_config.lease_time == 3600
+          - ip_space_info.objects[0].inheritance_sources.dhcp_config.lease_time.action == "override"
+
   always:
     # Cleanup if the test fails
     - name: "Delete IP Space"

--- a/tests/integration/targets/ipam_ip_space/tasks/main.yml
+++ b/tests/integration/targets/ipam_ip_space/tasks/main.yml
@@ -1,0 +1,125 @@
+---
+- module_defaults:
+    group/infoblox.bloxone.all:
+      csp_url: "{{ csp_url }}"
+      api_key: "{{ api_key }}"
+  block:
+    # Create a random IP space name to avoid conflicts
+    - ansible.builtin.set_fact:
+        name: "test-ip-space-{{ 999999 | random | string }}"
+
+    # Basic tests for IP space
+    - name: "Create an IP space (check mode)"
+      infoblox.bloxone.ipam_ip_space:
+        name: "{{ name }}"
+        state: "present"
+      check_mode: true
+      register: ip_space
+    - name: Get information about the IP space
+      infoblox.bloxone.ipam_ip_space_info:
+        filters:
+          name: "{{ name }}"
+      register: ip_space_info
+    - assert:
+        that:
+          - ip_space is changed
+          - ip_space is not failed
+          - ip_space_info.results | length == 0
+
+    - name: "Create an IP space"
+      infoblox.bloxone.ipam_ip_space:
+          name: "{{ name }}"
+          state: "present"
+      register: ip_space
+    - name: Get information about the IP space
+      infoblox.bloxone.ipam_ip_space_info:
+        filters:
+          name: "{{ name }}"
+      register: ip_space_info
+    - assert:
+        that:
+          - ip_space is not failed
+          - ip_space_info.results | length == 1
+          - ip_space_info.results[0].id == ip_space.id
+          - ip_space_info.results[0].name == ip_space.item.name
+
+    - name: "Create an IP space (idempotent)"
+      infoblox.bloxone.ipam_ip_space:
+          name: "{{ name }}"
+          state: "present"
+      register: ip_space
+    - assert:
+        that:
+          - ip_space is not changed
+          - ip_space is not failed
+
+    - name: "Delete IP Space (check mode)"
+      infoblox.bloxone.ipam_ip_space:
+        name: "{{ name }}"
+        state: "absent"
+      check_mode: true
+      register: ip_space
+    - name: Get information about the IP space
+      infoblox.bloxone.ipam_ip_space_info:
+        filters:
+          name: "{{ name }}"
+      register: ip_space_info
+    - assert:
+        that:
+          - ip_space is changed
+          - ip_space is not failed
+          - ip_space_info.results | length == 1
+
+    - name: "Delete IP Space"
+      infoblox.bloxone.ipam_ip_space:
+          name: "{{ name }}"
+          state: "absent"
+      register: ip_space
+    - name: Get information about the IP space
+      infoblox.bloxone.ipam_ip_space_info:
+          filters:
+            name: "{{ name }}"
+      register: ip_space_info
+    - assert:
+        that:
+          - ip_space is changed
+          - ip_space is not failed
+          - ip_space_info.results | length == 0
+
+    - name: "Delete IP Space (idempotent)"
+      infoblox.bloxone.ipam_ip_space:
+          name: "{{ name }}"
+          state: "absent"
+      register: ip_space
+    - assert:
+        that:
+          - ip_space is not changed
+          - ip_space is not failed
+
+    # Create an IP space with tags
+    - name: "Create an IP space with tags"
+      infoblox.bloxone.ipam_ip_space:
+        name: "{{ name }}"
+        tags:
+          location: "site-1"
+        state: "present"
+      register: ip_space
+    - name: Get information about the IP space
+      infoblox.bloxone.ipam_ip_space_info:
+        filters:
+          name: "{{ name }}"
+      register: ip_space_info
+    - assert:
+        that:
+          - ip_space is not failed
+          - ip_space_info.results | length == 1
+          - ip_space_info.results[0].id == ip_space.id
+          - ip_space_info.results[0].tags.location == "site-1"
+
+  always:
+    # Cleanup if the test fails
+    - name: "Delete IP Space"
+      infoblox.bloxone.ipam_ip_space:
+        name: "{{ name }}"
+        state: "absent"
+      ignore_errors: true

--- a/tests/integration/targets/ipam_ip_space/tasks/main.yml
+++ b/tests/integration/targets/ipam_ip_space/tasks/main.yml
@@ -24,7 +24,7 @@
         that:
           - ip_space is changed
           - ip_space is not failed
-          - ip_space_info.results | length == 0
+          - ip_space_info.objects | length == 0
 
     - name: "Create an IP space"
       infoblox.bloxone.ipam_ip_space:
@@ -39,9 +39,9 @@
     - assert:
         that:
           - ip_space is not failed
-          - ip_space_info.results | length == 1
-          - ip_space_info.results[0].id == ip_space.id
-          - ip_space_info.results[0].name == ip_space.item.name
+          - ip_space_info.objects | length == 1
+          - ip_space_info.objects[0].id == ip_space.id
+          - ip_space_info.objects[0].name == ip_space.object.name
 
     - name: "Create an IP space (idempotent)"
       infoblox.bloxone.ipam_ip_space:
@@ -68,7 +68,7 @@
         that:
           - ip_space is changed
           - ip_space is not failed
-          - ip_space_info.results | length == 1
+          - ip_space_info.objects | length == 1
 
     - name: "Delete IP Space"
       infoblox.bloxone.ipam_ip_space:
@@ -84,7 +84,7 @@
         that:
           - ip_space is changed
           - ip_space is not failed
-          - ip_space_info.results | length == 0
+          - ip_space_info.objects | length == 0
 
     - name: "Delete IP Space (idempotent)"
       infoblox.bloxone.ipam_ip_space:
@@ -112,9 +112,9 @@
     - assert:
         that:
           - ip_space is not failed
-          - ip_space_info.results | length == 1
-          - ip_space_info.results[0].id == ip_space.id
-          - ip_space_info.results[0].tags.location == "site-1"
+          - ip_space_info.objects | length == 1
+          - ip_space_info.objects[0].id == ip_space.id
+          - ip_space_info.objects[0].tags.location == "site-1"
 
   always:
     # Cleanup if the test fails

--- a/tests/integration/targets/ipam_ip_space_info/tasks/main.yml
+++ b/tests/integration/targets/ipam_ip_space_info/tasks/main.yml
@@ -1,0 +1,61 @@
+---
+- module_defaults:
+    group/infoblox.bloxone.all:
+      csp_url: "{{ csp_url }}"
+      api_key: "{{ api_key }}"
+  block:
+    - ansible.builtin.set_fact:
+        name: "test-ip-space-{{ 999999 | random | string }}"
+        tag_value: "site-{{ 999999 | random | string }}"
+
+    - name: "Create an IP space"
+      infoblox.bloxone.ipam_ip_space:
+        name: "{{ name }}"
+        tags:
+          location: "{{ tag_value }}"
+        state: "present"
+      register: ip_space
+
+    - name: Get IP Space information by ID
+      infoblox.bloxone.ipam_ip_space_info:
+        id: "{{ ip_space.id }}"
+      register: ip_space_info
+    - assert:
+        that:
+          - ip_space_info.results | length == 1
+          - ip_space_info.results[0].name == ip_space.item.name
+
+    - name: Get IP Space information by filters (name)
+      infoblox.bloxone.ipam_ip_space_info:
+        filters:
+          name: "{{ name }}"
+      register: ip_space_info
+    - assert:
+        that:
+          - ip_space_info.results | length == 1
+          - ip_space_info.results[0].id == ip_space.id
+
+    - name: Get IP Space information by filter query
+      infoblox.bloxone.ipam_ip_space_info:
+        filter_query: "name=='{{ name }}'"
+    - assert:
+        that:
+          - ip_space_info.results | length == 1
+          - ip_space_info.results[0].id == ip_space.id
+
+    - name: Get IP Space information by tag filters
+      infoblox.bloxone.ipam_ip_space_info:
+        tag_filters:
+          location: "{{ tag_value }}"
+    - assert:
+        that:
+          - ip_space_info.results | length == 1
+          - ip_space_info.results[0].id == ip_space.id
+
+  always:
+    # Cleanup if the test fails
+    - name: "Delete IP Space"
+      infoblox.bloxone.ipam_ip_space:
+        name: "{{ name }}"
+        state: "absent"
+      ignore_errors: true

--- a/tests/integration/targets/ipam_ip_space_info/tasks/main.yml
+++ b/tests/integration/targets/ipam_ip_space_info/tasks/main.yml
@@ -22,8 +22,8 @@
       register: ip_space_info
     - assert:
         that:
-          - ip_space_info.results | length == 1
-          - ip_space_info.results[0].name == ip_space.item.name
+          - ip_space_info.objects | length == 1
+          - ip_space_info.objects[0].name == ip_space.object.name
 
     - name: Get IP Space information by filters (name)
       infoblox.bloxone.ipam_ip_space_info:
@@ -32,16 +32,16 @@
       register: ip_space_info
     - assert:
         that:
-          - ip_space_info.results | length == 1
-          - ip_space_info.results[0].id == ip_space.id
+          - ip_space_info.objects | length == 1
+          - ip_space_info.objects[0].id == ip_space.id
 
     - name: Get IP Space information by filter query
       infoblox.bloxone.ipam_ip_space_info:
         filter_query: "name=='{{ name }}'"
     - assert:
         that:
-          - ip_space_info.results | length == 1
-          - ip_space_info.results[0].id == ip_space.id
+          - ip_space_info.objects | length == 1
+          - ip_space_info.objects[0].id == ip_space.id
 
     - name: Get IP Space information by tag filters
       infoblox.bloxone.ipam_ip_space_info:
@@ -49,8 +49,8 @@
           location: "{{ tag_value }}"
     - assert:
         that:
-          - ip_space_info.results | length == 1
-          - ip_space_info.results[0].id == ip_space.id
+          - ip_space_info.objects | length == 1
+          - ip_space_info.objects[0].id == ip_space.id
 
   always:
     # Cleanup if the test fails


### PR DESCRIPTION
- added BloxoneAnsibleModule as a common util for all the new modules. This module uses the bloxone-python-client.
- added implementation for `ipam_ip_space` and `ipam_ip_space_info` modules. 
- deprecated `b1_ipam_ip_space` and `b1_ipam_ip_space_gather` modules
- added workflow action to run integration tests