### PR TITLE
[fix] Minor Changes to DNS Delegation Info

### DIFF
--- a/plugins/modules/dns_delegation_info.py
+++ b/plugins/modules/dns_delegation_info.py
@@ -56,11 +56,10 @@ EXAMPLES = r"""
         filters:
           fqdn: "delegation.example_zone."
           
-    - name: Get Delegation information by filters (e.g. fqdn,view)
+    - name: Get Delegation information by filters (e.g. fqdn)
       infoblox.bloxone.dns_delegation_info:
         filters:
           fqdn: "delegation.example_zone."
-          view: '{{ view_id }}'
 
     - name: Get Delegation information by raw filter query
       infoblox.bloxone.dns_delegation_info:

--- a/tests/integration/targets/dns_delegation_info/tasks/main.yml
+++ b/tests/integration/targets/dns_delegation_info/tasks/main.yml
@@ -25,7 +25,6 @@
       infoblox.bloxone.dns_delegation_info:
         filters:
           fqdn: "{{ delegation_fqdn }}"
-          view: "{{ _view.id }}"
       register: delegation_info
     - assert:
         that:

--- a/tests/integration/targets/dns_delegation_info/tasks/main.yml
+++ b/tests/integration/targets/dns_delegation_info/tasks/main.yml
@@ -1,4 +1,8 @@
 ---
+
+#TODO: add tests
+  # - Filter Delegation using view
+
 - module_defaults:
     group/infoblox.bloxone.all:
       csp_url: "{{ csp_url }}"


### PR DESCRIPTION
- Removed `view` from the filter field and from examples due to NORTHSTAR-12614